### PR TITLE
Support hyperloglog

### DIFF
--- a/include/pika_command.h
+++ b/include/pika_command.h
@@ -152,9 +152,14 @@ const std::string kCmdNameSInter = "sinter";
 const std::string kCmdNameSInterstore = "sinterstore";
 const std::string kCmdNameSIsmember = "sismember";
 const std::string kCmdNameSDiff = "sdiff";
-const std::string kCmdNameSDiffstore= "sdiffstore";
-const std::string kCmdNameSMove= "smove";
-const std::string kCmdNameSRandmember= "srandmember";
+const std::string kCmdNameSDiffstore = "sdiffstore";
+const std::string kCmdNameSMove = "smove";
+const std::string kCmdNameSRandmember = "srandmember";
+
+//HyperLogLog
+const std::string kCmdNamePfAdd = "pfadd";
+const std::string kCmdNamePfCount = "pfcount";
+const std::string kCmdNamePfMerge = "pfmerge";
 
 typedef pink::RedisCmdArgsType PikaCmdArgsType;
 
@@ -177,6 +182,7 @@ enum CmdFlags {
   kCmdFlagsSet            = 8,
   kCmdFlagsZset           = 10,
   kCmdFlagsBit            = 12,
+  kCmdFlagsHyperLogLog    = 14,
   kCmdFlagsNoLocal        = 0, //default nolocal
   kCmdFlagsLocal          = 16,
   kCmdFlagsNoSuspend      = 0, //default nosuspend

--- a/include/pika_hyperloglog.h
+++ b/include/pika_hyperloglog.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present, Qihoo, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#ifndef PIKA_HYPERLOGLOG_H_
+#define PIKA_HYPERLOGLOG_H_
+
+#include "pika_command.h"
+#include "nemo.h"
+
+/*
+ * hyperloglog
+ */
+class PfAddCmd : public Cmd {
+public:
+	PfAddCmd() {};
+	virtual void Do();
+private:
+	std::string key_;
+	std::vector<std::string> values_;
+	virtual void DoInitial(PikaCmdArgsType &argvs, const CmdInfo* const ptr_info);
+	virtual void Clear() {
+      values_.clear();
+    }
+};
+
+class PfCountCmd : public Cmd {
+public:
+	PfCountCmd() {};
+	virtual void Do();
+private:
+	std::vector<std::string> keys_;
+	virtual void DoInitial(PikaCmdArgsType &argvs, const CmdInfo* const ptr_info);
+	virtual void Clear() {
+      keys_.clear();
+    }
+};
+
+class PfMergeCmd : public Cmd {
+public:
+	PfMergeCmd() {};
+	virtual void Do();
+private:
+	std::vector<std::string> keys_;
+	virtual void DoInitial(PikaCmdArgsType &argvs, const CmdInfo* const ptr_info);
+	virtual void Clear() {
+      keys_.clear();
+    }
+};
+#endif

--- a/include/pika_hyperloglog.h
+++ b/include/pika_hyperloglog.h
@@ -14,38 +14,39 @@
  */
 class PfAddCmd : public Cmd {
 public:
-	PfAddCmd() {};
-	virtual void Do();
+  PfAddCmd() {};
+  virtual void Do();
 private:
-	std::string key_;
-	std::vector<std::string> values_;
-	virtual void DoInitial(PikaCmdArgsType &argvs, const CmdInfo* const ptr_info);
-	virtual void Clear() {
-      values_.clear();
-    }
+  std::string key_;
+  std::vector<std::string> values_;
+  virtual void DoInitial(PikaCmdArgsType &argvs, const CmdInfo* const ptr_info);
+  virtual void Clear() {
+    values_.clear();
+  }
 };
 
 class PfCountCmd : public Cmd {
 public:
-	PfCountCmd() {};
-	virtual void Do();
+  PfCountCmd() {};
+  virtual void Do();
 private:
-	std::vector<std::string> keys_;
-	virtual void DoInitial(PikaCmdArgsType &argvs, const CmdInfo* const ptr_info);
-	virtual void Clear() {
-      keys_.clear();
-    }
+  std::vector<std::string> keys_;
+  virtual void DoInitial(PikaCmdArgsType &argvs, const CmdInfo* const ptr_info);
+  virtual void Clear() {
+    keys_.clear();
+  }
 };
 
 class PfMergeCmd : public Cmd {
 public:
-	PfMergeCmd() {};
-	virtual void Do();
+  PfMergeCmd() {};
+  virtual void Do();
 private:
-	std::vector<std::string> keys_;
-	virtual void DoInitial(PikaCmdArgsType &argvs, const CmdInfo* const ptr_info);
-	virtual void Clear() {
-      keys_.clear();
-    }
+  std::vector<std::string> keys_;
+  virtual void DoInitial(PikaCmdArgsType &argvs, const CmdInfo* const ptr_info);
+  virtual void Clear() {
+    keys_.clear();
+  }
 };
+
 #endif

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -4,6 +4,7 @@
 // of patent rights can be found in the PATENTS file in the same directory.
 
 #include "pika_admin.h"
+#include "pika_slot.h"
 #include "pika_kv.h"
 #include "pika_hash.h"
 #include "pika_list.h"
@@ -54,7 +55,7 @@ void InitCmdInfoTable() {
   CmdInfo* dbsizeptr = new CmdInfo(kCmdNameDbsize, 1, kCmdFlagsRead | kCmdFlagsAdmin);
   cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNameDbsize, dbsizeptr));
 
-    
+
   //migrate slot
   CmdInfo* slotmgrtslotptr = new CmdInfo(kCmdNameSlotsMgrtSlot, 5, kCmdFlagsRead | kCmdFlagsAdmin);
   cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNameSlotsMgrtSlot, slotmgrtslotptr));
@@ -76,8 +77,8 @@ void InitCmdInfoTable() {
   cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNameSlotsDel, slotsdelptr));
   CmdInfo* slotsscanptr = new CmdInfo(kCmdNameSlotsScan, -3, kCmdFlagsRead | kCmdFlagsAdmin);
   cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNameSlotsScan, slotsscanptr));
-    
-    
+
+
   //Kv
   ////SetCmd
   CmdInfo* setptr = new CmdInfo(kCmdNameSet, -3, kCmdFlagsWrite | kCmdFlagsKv);
@@ -461,7 +462,7 @@ void InitCmdTable(std::unordered_map<std::string, Cmd*> *cmd_table) {
   cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameSlotsDel, slotsdelptr));
   Cmd* slotsscanptr = new SlotsScanCmd();
   cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameSlotsScan, slotsscanptr));
-    
+
   //Kv
   ////SetCmd
   Cmd* setptr = new SetCmd();
@@ -553,49 +554,49 @@ void InitCmdTable(std::unordered_map<std::string, Cmd*> *cmd_table) {
   //Hash
   ////HDelCmd
   Cmd* hdelptr = new HDelCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHDel, hdelptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHDel, hdelptr));
   ////HSetCmd
   Cmd* hsetptr = new HSetCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHSet, hsetptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHSet, hsetptr));
   ////HGetCmd
   Cmd* hgetptr = new HGetCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHGet, hgetptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHGet, hgetptr));
   ////HGetallCmd
   Cmd* hgetallptr = new HGetallCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHGetall, hgetallptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHGetall, hgetallptr));
   ////HExistsCmd
   Cmd* hexistsptr = new HExistsCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHExists, hexistsptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHExists, hexistsptr));
   ////HIncrbyCmd
   Cmd* hincrbyptr = new HIncrbyCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHIncrby, hincrbyptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHIncrby, hincrbyptr));
   ////HIncrbyfloatCmd
   Cmd* hincrbyfloatptr = new HIncrbyfloatCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHIncrbyfloat, hincrbyfloatptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHIncrbyfloat, hincrbyfloatptr));
   ////HKeysCmd
   Cmd* hkeysptr = new HKeysCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHKeys, hkeysptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHKeys, hkeysptr));
   ////HLenCmd
   Cmd* hlenptr = new HLenCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHLen, hlenptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHLen, hlenptr));
   ////HMgetCmd
   Cmd* hmgetptr = new HMgetCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHMget, hmgetptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHMget, hmgetptr));
   ////HMsetCmd
   Cmd* hmsetptr = new HMsetCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHMset, hmsetptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHMset, hmsetptr));
   ////HSetnxCmd
   Cmd* hsetnxptr = new HSetnxCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHSetnx, hsetnxptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHSetnx, hsetnxptr));
   ////HStrlenCmd
   Cmd* hstrlenptr = new HStrlenCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHStrlen, hstrlenptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHStrlen, hstrlenptr));
   ////HValsCmd
   Cmd* hvalsptr = new HValsCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHVals, hvalsptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHVals, hvalsptr));
   ////HScanCmd
   Cmd* hscanptr = new HScanCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHScan, hscanptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameHScan, hscanptr));
   //List
   Cmd* lindexptr = new LIndexCmd();
   cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameLIndex, lindexptr));
@@ -604,7 +605,7 @@ void InitCmdTable(std::unordered_map<std::string, Cmd*> *cmd_table) {
   Cmd* llenptr = new LLenCmd();
   cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameLLen, llenptr));
   Cmd* lpopptr = new LPopCmd();
-  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameLPop, lpopptr));  
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameLPop, lpopptr));
   Cmd* lpushptr = new LPushCmd();
   cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameLPush, lpushptr));
   Cmd* lpushxptr = new LPushxCmd();
@@ -768,7 +769,7 @@ void InitCmdTable(std::unordered_map<std::string, Cmd*> *cmd_table) {
 
 }
 
-Cmd* GetCmdFromTable(const std::string& opt, 
+Cmd* GetCmdFromTable(const std::string& opt,
     const std::unordered_map<std::string, Cmd*> &cmd_table) {
   std::unordered_map<std::string, Cmd*>::const_iterator it = cmd_table.find(opt);
   if (it != cmd_table.end()) {

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -380,7 +380,7 @@ void InitCmdInfoTable() {
   CmdInfo* pfaddptr = new CmdInfo(kCmdNamePfAdd, -3, kCmdFlagsWrite | kCmdFlagsHyperLogLog);
   cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNamePfAdd, pfaddptr));
   ////PfCount
-  CmdInfo* pfcountptr = new CmdInfo(kCmdNamePfCount, -3, kCmdFlagsRead | kCmdFlagsHyperLogLog);
+  CmdInfo* pfcountptr = new CmdInfo(kCmdNamePfCount, -2, kCmdFlagsRead | kCmdFlagsHyperLogLog);
   cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNamePfCount, pfcountptr));
   ////PfMerge
   CmdInfo* pfmergeptr = new CmdInfo(kCmdNamePfMerge, -3, kCmdFlagsWrite | kCmdFlagsHyperLogLog);

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -4,13 +4,13 @@
 // of patent rights can be found in the PATENTS file in the same directory.
 
 #include "pika_admin.h"
-#include "pika_slot.h"
 #include "pika_kv.h"
 #include "pika_hash.h"
 #include "pika_list.h"
 #include "pika_set.h"
 #include "pika_zset.h"
 #include "pika_bit.h"
+#include "pika_hyperloglog.h"
 
 static std::unordered_map<std::string, CmdInfo*> cmd_infos(300);    /* Table for CmdInfo */
 
@@ -54,6 +54,7 @@ void InitCmdInfoTable() {
   CmdInfo* dbsizeptr = new CmdInfo(kCmdNameDbsize, 1, kCmdFlagsRead | kCmdFlagsAdmin);
   cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNameDbsize, dbsizeptr));
 
+    
   //migrate slot
   CmdInfo* slotmgrtslotptr = new CmdInfo(kCmdNameSlotsMgrtSlot, 5, kCmdFlagsRead | kCmdFlagsAdmin);
   cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNameSlotsMgrtSlot, slotmgrtslotptr));
@@ -75,7 +76,8 @@ void InitCmdInfoTable() {
   cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNameSlotsDel, slotsdelptr));
   CmdInfo* slotsscanptr = new CmdInfo(kCmdNameSlotsScan, -3, kCmdFlagsRead | kCmdFlagsAdmin);
   cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNameSlotsScan, slotsscanptr));
-
+    
+    
   //Kv
   ////SetCmd
   CmdInfo* setptr = new CmdInfo(kCmdNameSet, -3, kCmdFlagsWrite | kCmdFlagsKv);
@@ -371,6 +373,17 @@ void InitCmdInfoTable() {
   ////BitCount
   CmdInfo* bitcountptr = new CmdInfo(kCmdNameBitCount, -2, kCmdFlagsRead | kCmdFlagsBit);
   cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNameBitCount, bitcountptr)).second;
+
+  //HyperLogLog
+  ////PfAdd
+  CmdInfo* pfaddptr = new CmdInfo(kCmdNamePfAdd, -3, kCmdFlagsWrite | kCmdFlagsHyperLogLog);
+  cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNamePfAdd, pfaddptr));
+  ////PfCount
+  CmdInfo* pfcountptr = new CmdInfo(kCmdNamePfCount, -3, kCmdFlagsRead | kCmdFlagsHyperLogLog);
+  cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNamePfCount, pfcountptr));
+  ////PfMerge
+  CmdInfo* pfmergeptr = new CmdInfo(kCmdNamePfMerge, -3, kCmdFlagsWrite | kCmdFlagsHyperLogLog);
+  cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNamePfMerge, pfmergeptr));
 }
 
 void DestoryCmdInfoTable() {
@@ -448,7 +461,7 @@ void InitCmdTable(std::unordered_map<std::string, Cmd*> *cmd_table) {
   cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameSlotsDel, slotsdelptr));
   Cmd* slotsscanptr = new SlotsScanCmd();
   cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameSlotsScan, slotsscanptr));
-
+    
   //Kv
   ////SetCmd
   Cmd* setptr = new SetCmd();
@@ -741,6 +754,17 @@ void InitCmdTable(std::unordered_map<std::string, Cmd*> *cmd_table) {
   ////bitopCmd
   Cmd* bitopptr = new BitOpCmd();
   cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameBitOp, bitopptr));
+
+  //HyperLogLog
+  ////pfaddCmd
+  Cmd * pfaddptr = new PfAddCmd();
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNamePfAdd, pfaddptr));
+  ////pfcountCmd
+  Cmd * pfcountptr = new PfCountCmd();
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNamePfCount, pfcountptr));
+  ////pfmergeCmd
+  Cmd * pfmergeptr = new PfMergeCmd();
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNamePfMerge, pfmergeptr));
 
 }
 

--- a/src/pika_hyperloglog.cc
+++ b/src/pika_hyperloglog.cc
@@ -13,8 +13,8 @@ extern PikaServer *g_pika_server;
 
 void PfAddCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info) {
   if (!ptr_info->CheckArg(argv.size())) {
-  res_.SetRes(CmdRes::kWrongNum, kCmdNamePfAdd);
-	return;
+    res_.SetRes(CmdRes::kWrongNum, kCmdNamePfAdd);
+    return;
   }
   key_ = argv[1];
   size_t pos = 2;
@@ -26,17 +26,17 @@ void PfAddCmd::Do() {
   nemo::Status s;
   s = g_pika_server->db()->PfAdd(key_, values_);
   if (s.ok()) {
-      res_.SetRes(CmdRes::kOk);
+    res_.SetRes(CmdRes::kOk);
   } else {
     res_.SetRes(CmdRes::kErrOther, s.ToString());
   }
 }
 
 void PfCountCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info) {
-//  if (!ptr_info->CheckArg(argv.size())) {
-  //  res_.SetRes(CmdRes::kWrongNum, kCmdNamePfCount);
-//	return;
- // }
+  if (!ptr_info->CheckArg(argv.size())) {
+    res_.SetRes(CmdRes::kWrongNum, kCmdNamePfCount);
+    return;
+  }
   size_t pos = 1;
   while (pos < argv.size()) {
     keys_.push_back(argv[pos++]);
@@ -58,7 +58,7 @@ void PfCountCmd::Do() {
 void PfMergeCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info) {
   if (!ptr_info->CheckArg(argv.size())) {
     res_.SetRes(CmdRes::kWrongNum, kCmdNamePfMerge);
-	return;
+    return;
   }
   size_t pos = 1;
   while (pos < argv.size()) {
@@ -69,7 +69,7 @@ void PfMergeCmd::Do() {
   nemo::Status s;
   s = g_pika_server->db()->PfMerge(keys_);
   if (s.ok()) {
-      res_.SetRes(CmdRes::kOk);
+    res_.SetRes(CmdRes::kOk);
   } else if (s.IsNotFound()) {
     res_.AppendStringLen(-1);
   } else {

--- a/src/pika_hyperloglog.cc
+++ b/src/pika_hyperloglog.cc
@@ -26,7 +26,7 @@ void PfAddCmd::Do() {
   nemo::Status s;
   s = g_pika_server->db()->PfAdd(key_, values_);
   if (s.ok()) {
-    res_.SetRes(CmdRes::kOk);
+    res_.AppendInteger(1);
   } else {
     res_.SetRes(CmdRes::kErrOther, s.ToString());
   }
@@ -48,8 +48,6 @@ void PfCountCmd::Do() {
   s = g_pika_server->db()->PfCount(keys_, value_);
   if (s.ok()) {
     res_.AppendInteger(value_);
-  } else if (s.IsNotFound()) {
-    res_.AppendStringLen(-1);
   } else {
     res_.SetRes(CmdRes::kErrOther, s.ToString());
   }
@@ -70,8 +68,6 @@ void PfMergeCmd::Do() {
   s = g_pika_server->db()->PfMerge(keys_);
   if (s.ok()) {
     res_.SetRes(CmdRes::kOk);
-  } else if (s.IsNotFound()) {
-    res_.AppendStringLen(-1);
   } else {
     res_.SetRes(CmdRes::kErrOther, s.ToString());
   }

--- a/src/pika_hyperloglog.cc
+++ b/src/pika_hyperloglog.cc
@@ -1,0 +1,78 @@
+// Copyright (c) 2015-present, Qihoo, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <vector>
+#include "slash_string.h"
+#include "nemo.h"
+#include "pika_server.h"
+#include "pika_hyperloglog.h"
+
+extern PikaServer *g_pika_server;
+
+void PfAddCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info) {
+  if (!ptr_info->CheckArg(argv.size())) {
+  res_.SetRes(CmdRes::kWrongNum, kCmdNamePfAdd);
+	return;
+  }
+  key_ = argv[1];
+  size_t pos = 2;
+  while (pos < argv.size()) {
+    values_.push_back(argv[pos++]);
+  }
+}
+void PfAddCmd::Do() {
+  nemo::Status s;
+  s = g_pika_server->db()->PfAdd(key_, values_);
+  if (s.ok()) {
+      res_.SetRes(CmdRes::kOk);
+  } else {
+    res_.SetRes(CmdRes::kErrOther, s.ToString());
+  }
+}
+
+void PfCountCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info) {
+//  if (!ptr_info->CheckArg(argv.size())) {
+  //  res_.SetRes(CmdRes::kWrongNum, kCmdNamePfCount);
+//	return;
+ // }
+  size_t pos = 1;
+  while (pos < argv.size()) {
+    keys_.push_back(argv[pos++]);
+  }
+}
+void PfCountCmd::Do() {
+  nemo::Status s;
+  int value_;
+  s = g_pika_server->db()->PfCount(keys_, value_);
+  if (s.ok()) {
+    res_.AppendInteger(value_);
+  } else if (s.IsNotFound()) {
+    res_.AppendStringLen(-1);
+  } else {
+    res_.SetRes(CmdRes::kErrOther, s.ToString());
+  }
+}
+
+void PfMergeCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info) {
+  if (!ptr_info->CheckArg(argv.size())) {
+    res_.SetRes(CmdRes::kWrongNum, kCmdNamePfMerge);
+	return;
+  }
+  size_t pos = 1;
+  while (pos < argv.size()) {
+    keys_.push_back(argv[pos++]);
+  }
+}
+void PfMergeCmd::Do() {
+  nemo::Status s;
+  s = g_pika_server->db()->PfMerge(keys_);
+  if (s.ok()) {
+      res_.SetRes(CmdRes::kOk);
+  } else if (s.IsNotFound()) {
+    res_.AppendStringLen(-1);
+  } else {
+    res_.SetRes(CmdRes::kErrOther, s.ToString());
+  }
+}

--- a/src/pika_hyperloglog.cc
+++ b/src/pika_hyperloglog.cc
@@ -22,11 +22,15 @@ void PfAddCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info) {
     values_.push_back(argv[pos++]);
   }
 }
+
 void PfAddCmd::Do() {
   nemo::Status s;
-  s = g_pika_server->db()->PfAdd(key_, values_);
-  if (s.ok()) {
+  bool update = false;
+  s = g_pika_server->db()->PfAdd(key_, values_, update);
+  if (s.ok() && update) {
     res_.AppendInteger(1);
+  } else if (s.ok() && !update) {
+    res_.AppendInteger(0);
   } else {
     res_.SetRes(CmdRes::kErrOther, s.ToString());
   }
@@ -42,6 +46,7 @@ void PfCountCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info)
     keys_.push_back(argv[pos++]);
   }
 }
+
 void PfCountCmd::Do() {
   nemo::Status s;
   int value_;
@@ -63,6 +68,7 @@ void PfMergeCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info)
     keys_.push_back(argv[pos++]);
   }
 }
+
 void PfMergeCmd::Do() {
   nemo::Status s;
   s = g_pika_server->db()->PfMerge(keys_);


### PR DESCRIPTION
Because the issue #55, So I want to support pfadd, pfcount and pfmerge, and I already add the data type of hyperloglog to [nemo](https://github.com/Qihoo360/nemo) .

I have used these codes to do a benchmark, and the result on my computer is:

    $ ./redis-benchmark -p 9221 -t pfadd pfcount pfmerge -r 10000 -n 10000
    ====== pfcount pfmerge -r 10000 -n 10000 ======
    100000 requests completed in 1.68 seconds
    50 parallel clients
    3 bytes payload
    keep alive: 1
    83.10% <= 1 milliseconds
    97.54% <= 2 milliseconds
    99.17% <= 3 milliseconds
    99.83% <= 4 milliseconds
    99.90% <= 6 milliseconds
    99.97% <= 7 milliseconds
    99.99% <= 8 milliseconds
    99.99% <= 13 milliseconds
    100.00% <= 14 milliseconds
    100.00% <= 16 milliseconds
    59382.42 requests per second

please review it, thanks.