### PR TITLE
fix deadlock between trysync and info 

### DIFF
--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -115,6 +115,7 @@ void TrysyncCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info)
 void TrysyncCmd::Do() {
   std::string ip_port = slash::IpPortString(slave_ip_, slave_port_);
   DLOG(INFO) << "Trysync, Slave ip_port: " << ip_port << " filenum: " << filenum_ << " pro_offset: " << pro_offset_;
+  slash::RWLock rwl(g_pika_server->rwlock(), true);
   slash::MutexLock l(&(g_pika_server->slave_mutex_));
   if (!g_pika_server->FindSlave(ip_port)) {
     SlaveItem s;
@@ -176,6 +177,7 @@ void BgsaveCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info) 
   }
 }
 void BgsaveCmd::Do() {
+  slash::RWLock rwl(g_pika_server->rwlock(), true);
   g_pika_server->Bgsave();
   const PikaServer::BGSaveInfo& info = g_pika_server->bgsave_info();
   char buf[256];

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -616,7 +616,7 @@ bool PikaServer::InitBgsaveEngine() {
   }
 
   {
-    RWLock l(&rwlock_, true);
+    //RWLock l(&rwlock_, true);
     {
       slash::MutexLock l(&bgsave_protector_);
       logger_->GetProducerStatus(&bgsave_info_.filenum, &bgsave_info_.offset);


### PR DESCRIPTION
add write lock in trysync and bgsave command and delete lock in bgsave function, avoid deadlock with infolog command. 
infolog locks g_pika_server->rwlock() and g_pika_server->slave_mutex_, but trysync locks g_pika_server->slave_mutex_ and g_pika_server->rwlock()(trysync may call bgsave, bgsave->InitBgsaveEngine locks g_pika_server->rwlock)
InfoReplication is same as infolog.