### PR TITLE
修改HLL测试文件

### DIFF
--- a/pikatests/tests/unit/hyperloglog.tcl
+++ b/pikatests/tests/unit/hyperloglog.tcl
@@ -1,8 +1,8 @@
 start_server {tags {"hll"}} {
-    test {HyperLogLog self test passes} {
-        catch {r pfselftest} e
-        set e
-    } {OK}
+#    test {HyperLogLog self test passes} {
+#        catch {r pfselftest} e
+#        set e
+#    } {OK}
 
     test {PFADD without arguments creates an HLL value} {
         r pfadd hll
@@ -39,93 +39,93 @@ start_server {tags {"hll"}} {
         set res
     } {5 10}
 
-    test {HyperLogLogs are promote from sparse to dense} {
-        r del hll
-        r config set hll-sparse-max-bytes 3000
-        set n 0
-        while {$n < 100000} {
-            set elements {}
-            for {set j 0} {$j < 100} {incr j} {lappend elements [expr rand()]}
-            incr n 100
-            r pfadd hll {*}$elements
-            set card [r pfcount hll]
-            set err [expr {abs($card-$n)}]
-            assert {$err < (double($card)/100)*5}
-            if {$n < 1000} {
-                assert {[r pfdebug encoding hll] eq {sparse}}
-            } elseif {$n > 10000} {
-                assert {[r pfdebug encoding hll] eq {dense}}
-            }
-        }
-    }
+#    test {HyperLogLogs are promote from sparse to dense} {
+#        r del hll
+#        r config set hll-sparse-max-bytes 3000
+#        set n 0
+#        while {$n < 100000} {
+#            set elements {}
+#            for {set j 0} {$j < 100} {incr j} {lappend elements [expr rand()]}
+#            incr n 100
+#            r pfadd hll {*}$elements
+#            set card [r pfcount hll]
+#            set err [expr {abs($card-$n)}]
+#            assert {$err < (double($card)/100)*5}
+#            if {$n < 1000} {
+#                assert {[r pfdebug encoding hll] eq {sparse}}
+#            } elseif {$n > 10000} {
+#                assert {[r pfdebug encoding hll] eq {dense}}
+#            }
+#        }
+#   }
 
-    test {HyperLogLog sparse encoding stress test} {
-        for {set x 0} {$x < 1000} {incr x} {
-            r del hll1 hll2
-            set numele [randomInt 100]
-            set elements {}
-            for {set j 0} {$j < $numele} {incr j} {
-                lappend elements [expr rand()]
-            }
+#    test {HyperLogLog sparse encoding stress test} {
+#        for {set x 0} {$x < 1000} {incr x} {
+#            r del hll1 hll2
+#            set numele [randomInt 100]
+#            set elements {}
+#            for {set j 0} {$j < $numele} {incr j} {
+#                lappend elements [expr rand()]
+#            }
             # Force dense representation of hll2
-            r pfadd hll2
-            r pfdebug todense hll2
-            r pfadd hll1 {*}$elements
-            r pfadd hll2 {*}$elements
-            assert {[r pfdebug encoding hll1] eq {sparse}}
-            assert {[r pfdebug encoding hll2] eq {dense}}
+#            r pfadd hll2
+#            r pfdebug todense hll2
+#            r pfadd hll1 {*}$elements
+#            r pfadd hll2 {*}$elements
+#            assert {[r pfdebug encoding hll1] eq {sparse}}
+#            assert {[r pfdebug encoding hll2] eq {dense}}
             # Cardinality estimated should match exactly.
-            assert {[r pfcount hll1] eq [r pfcount hll2]}
-        }
-    }
+#            assert {[r pfcount hll1] eq [r pfcount hll2]}
+#        }
+#   }
 
-    test {Corrupted sparse HyperLogLogs are detected: Additionl at tail} {
-        r del hll
-        r pfadd hll a b c
-        r append hll "hello"
-        set e {}
-        catch {r pfcount hll} e
-        set e
-    } {*INVALIDOBJ*}
+#    test {Corrupted sparse HyperLogLogs are detected: Additionl at tail} {
+#        r del hll
+#        r pfadd hll a b c
+#        r append hll "hello"
+#        set e {}
+#        catch {r pfcount hll} e
+#        set e
+#    } {*INVALIDOBJ*}
 
-    test {Corrupted sparse HyperLogLogs are detected: Broken magic} {
-        r del hll
-        r pfadd hll a b c
-        r setrange hll 0 "0123"
-        set e {}
-        catch {r pfcount hll} e
-        set e
-    } {*WRONGTYPE*}
+#    test {Corrupted sparse HyperLogLogs are detected: Broken magic} {
+#        r del hll
+#        r pfadd hll a b c
+#        r setrange hll 0 "0123"
+#        set e {}
+#        catch {r pfcount hll} e
+#        set e
+#    } {*WRONGTYPE*}
 
-    test {Corrupted sparse HyperLogLogs are detected: Invalid encoding} {
-        r del hll
-        r pfadd hll a b c
-        r setrange hll 4 "x"
-        set e {}
-        catch {r pfcount hll} e
-        set e
-    } {*WRONGTYPE*}
+#    test {Corrupted sparse HyperLogLogs are detected: Invalid encoding} {
+#        r del hll
+#        r pfadd hll a b c
+#        r setrange hll 4 "x"
+#        set e {}
+#        catch {r pfcount hll} e
+#        set e
+#    } {*WRONGTYPE*}
 
-    test {Corrupted dense HyperLogLogs are detected: Wrong length} {
-        r del hll
-        r pfadd hll a b c
-        r setrange hll 4 "\x00"
-        set e {}
-        catch {r pfcount hll} e
-        set e
-    } {*WRONGTYPE*}
+#    test {Corrupted dense HyperLogLogs are detected: Wrong length} {
+#        r del hll
+#        r pfadd hll a b c
+#        r setrange hll 4 "\x00"
+#        set e {}
+#        catch {r pfcount hll} e
+#        set e
+#    } {*WRONGTYPE*}
 
-    test {PFADD, PFCOUNT, PFMERGE type checking works} {
-        r set foo bar
-        catch {r pfadd foo 1} e
-        assert_match {*WRONGTYPE*} $e
-        catch {r pfcount foo} e
-        assert_match {*WRONGTYPE*} $e
-        catch {r pfmerge bar foo} e
-        assert_match {*WRONGTYPE*} $e
-        catch {r pfmerge foo bar} e
-        assert_match {*WRONGTYPE*} $e
-    }
+#    test {PFADD, PFCOUNT, PFMERGE type checking works} {
+#        r set foo bar
+#        catch {r pfadd foo 1} e
+#        assert_match {*WRONGTYPE*} $e
+#        catch {r pfcount foo} e
+#        assert_match {*WRONGTYPE*} $e
+#        catch {r pfmerge bar foo} e
+#        assert_match {*WRONGTYPE*} $e
+#        catch {r pfmerge foo bar} e
+#        assert_match {*WRONGTYPE*} $e
+#    }
 
     test {PFMERGE results on the cardinality of union of sets} {
         r del hll hll1 hll2 hll3
@@ -138,7 +138,7 @@ start_server {tags {"hll"}} {
 
     test {PFCOUNT multiple-keys merge returns cardinality of union} {
         r del hll1 hll2 hll3
-        for {set x 1} {$x < 10000} {incr x} {
+        for {set x 1} {$x < 100000} {incr x} {
             # Force dense representation of hll2
             r pfadd hll1 "foo-$x"
             r pfadd hll2 "bar-$x"
@@ -151,20 +151,81 @@ start_server {tags {"hll"}} {
         }
     }
 
-    test {PFDEBUG GETREG returns the HyperLogLog raw registers} {
-        r del hll
-        r pfadd hll 1 2 3
-        llength [r pfdebug getreg hll]
-    } {16384}
-
-    test {PFADD / PFCOUNT cache invalidation works} {
-        r del hll
-        r pfadd hll a b c
-        r pfcount hll
-        assert {[r getrange hll 15 15] eq "\x00"}
-        r pfadd hll a b c
-        assert {[r getrange hll 15 15] eq "\x00"}
-        r pfadd hll 1 2 3
-        assert {[r getrange hll 15 15] eq "\x80"}
+    test {HYPERLOGLOG press test: 5w, 10w, 15w, 30w} {
+        r del hll1
+        for {set x 1} {$x <= 300000} {incr x} {
+            r pfadd hll1 "foo-$x"
+            if {$x == 50000} {
+	    	set card [r pfcount hll1]
+            	set realcard [expr {$x*1}]
+            	set err [expr {abs($card-$realcard)}]
+            	assert {$err < $realcard * 0.01}
+	    	
+		set d_err [expr {$card * 1.0}]
+		set d_realcard [expr {$realcard * 1.0}]
+	    	set err_precentage [expr {double($err / $realcard)}]
+	    	puts "$x error rate: $err_precentage"
+	    }
+            if {$x == 100000} {
+	    	set card [r pfcount hll1]
+            	set realcard [expr {$x*1}]
+            	set err [expr {abs($card-$realcard)}]
+	    	set err_precentage [expr {$err / $realcard}]
+            	assert {$err < $realcard * 0.01}
+	    	
+		set d_err [expr {$card * 1.0}]
+		set d_realcard [expr {$realcard * 1.0}]
+	    	set err_precentage [expr {double($err / $realcard)}]
+	    	puts "$x error rate: $err_precentage"
+	    }
+            if {$x == 150000} {
+	    	set card [r pfcount hll1]
+            	set realcard [expr {$x*1}]
+            	set err [expr {abs($card-$realcard)}]
+	    	set err_precentage [expr {$err / $realcard}]
+            	assert {$err < $realcard * 0.01}
+	    	
+		set d_err [expr {$card * 1.0}]
+		set d_realcard [expr {$realcard * 1.0}]
+	    	set err_precentage [expr {double($err / $realcard)}]
+	    	puts "$x error rate: $err_precentage"
+	    }
+            if {$x == 300000} {
+	    	set card [r pfcount hll1]
+            	set realcard [expr {$x*1}]
+            	set err [expr {abs($card-$realcard)}]
+	    	set err_precentage [expr {$err / $realcard}]
+            	assert {$err < $realcard * 0.01}
+	    	
+		set d_err [expr {$card * 1.0}]
+		set d_realcard [expr {$realcard * 1.0}]
+	    	set err_precentage [expr {double($err / $realcard)}]
+	    	puts "$x error rate: $err_precentage"
+	    }
+        }
     }
+
+#    test {PFDEBUG GETREG returns the HyperLogLog raw registers} {
+#        r del hll
+#        r pfadd hll 1 2 3
+#        llength [r pfdebug getreg hll]
+#   } {16384}
+
+
+#    test {PFDEBUG GETREG returns the HyperLogLog raw registers} {
+#        r del hll
+#        r pfadd hll 1 2 3
+#        llength [r pfdebug getreg hll]
+#   } {16384}
+
+#    test {PFADD / PFCOUNT cache invalidation works} {
+#        r del hll
+#        r pfadd hll a b c
+#        r pfcount hll
+#        assert {[r getrange hll 15 15] eq "\x00"}
+#        r pfadd hll a b c
+#        assert {[r getrange hll 15 15] eq "\x00"}
+#        r pfadd hll 1 2 3
+#        assert {[r getrange hll 15 15] eq "\x80"}
+#    }
 }

--- a/pikatests/tests/unit/hyperloglog.tcl
+++ b/pikatests/tests/unit/hyperloglog.tcl
@@ -151,56 +151,75 @@ start_server {tags {"hll"}} {
         }
     }
 
-    test {HYPERLOGLOG press test: 5w, 10w, 15w, 30w} {
+    test {HYPERLOGLOG press test: 5w, 10w, 15w, 20w, 30w, 50w, 100w} {
         r del hll1
-        for {set x 1} {$x <= 300000} {incr x} {
+        for {set x 1} {$x <= 1000000} {incr x} {
             r pfadd hll1 "foo-$x"
             if {$x == 50000} {
 	    	set card [r pfcount hll1]
             	set realcard [expr {$x*1}]
             	set err [expr {abs($card-$realcard)}]
-            	assert {$err < $realcard * 0.01}
 	    	
-		set d_err [expr {$card * 1.0}]
+		set d_err [expr {$err * 1.0}]
 		set d_realcard [expr {$realcard * 1.0}]
-	    	set err_precentage [expr {double($err / $realcard)}]
+	    	set err_precentage [expr {double($d_err / $d_realcard)}]
 	    	puts "$x error rate: $err_precentage"
+           	assert {$err < $realcard * 0.01}
 	    }
             if {$x == 100000} {
 	    	set card [r pfcount hll1]
             	set realcard [expr {$x*1}]
             	set err [expr {abs($card-$realcard)}]
-	    	set err_precentage [expr {$err / $realcard}]
-            	assert {$err < $realcard * 0.01}
 	    	
-		set d_err [expr {$card * 1.0}]
+		set d_err [expr {$err * 1.0}]
 		set d_realcard [expr {$realcard * 1.0}]
-	    	set err_precentage [expr {double($err / $realcard)}]
+	    	set err_precentage [expr {double($d_err / $d_realcard)}]
 	    	puts "$x error rate: $err_precentage"
+          	assert {$err < $realcard * 0.01}
 	    }
             if {$x == 150000} {
 	    	set card [r pfcount hll1]
             	set realcard [expr {$x*1}]
             	set err [expr {abs($card-$realcard)}]
-	    	set err_precentage [expr {$err / $realcard}]
-            	assert {$err < $realcard * 0.01}
 	    	
-		set d_err [expr {$card * 1.0}]
+		set d_err [expr {$err * 1.0}]
 		set d_realcard [expr {$realcard * 1.0}]
-	    	set err_precentage [expr {double($err / $realcard)}]
+	    	set err_precentage [expr {double($d_err / $d_realcard)}]
 	    	puts "$x error rate: $err_precentage"
+            	assert {$err < $realcard * 0.01}
 	    }
             if {$x == 300000} {
 	    	set card [r pfcount hll1]
             	set realcard [expr {$x*1}]
             	set err [expr {abs($card-$realcard)}]
-	    	set err_precentage [expr {$err / $realcard}]
-            	assert {$err < $realcard * 0.01}
 	    	
-		set d_err [expr {$card * 1.0}]
+		set d_err [expr {$err * 1.0}]
 		set d_realcard [expr {$realcard * 1.0}]
-	    	set err_precentage [expr {double($err / $realcard)}]
+	    	set err_precentage [expr {double($d_err / $d_realcard)}]
 	    	puts "$x error rate: $err_precentage"
+            	assert {$err < $realcard * 0.01}
+	    }
+            if {$x == 500000} {
+	    	set card [r pfcount hll1]
+            	set realcard [expr {$x*1}]
+            	set err [expr {abs($card-$realcard)}]
+	    	
+		set d_err [expr {$err * 1.0}]
+		set d_realcard [expr {$realcard * 1.0}]
+	    	set err_precentage [expr {double($d_err / $d_realcard)}]
+	    	puts "$x error rate: $err_precentage"
+            	assert {$err < $realcard * 0.01}
+	    }
+            if {$x == 1000000} {
+	    	set card [r pfcount hll1]
+            	set realcard [expr {$x*1}]
+            	set err [expr {abs($card-$realcard)}]
+	    	
+		set d_err [expr {$err * 1.0}]
+		set d_realcard [expr {$realcard * 1.0}]
+	    	set err_precentage [expr {double($d_err / $d_realcard)}]
+	    	puts "$x error rate: $err_precentage"
+            	assert {$err < $realcard * 0.03}
 	    }
         }
     }


### PR DESCRIPTION
修改HLL测试文件, 注释不支持的命令并添加精度压力测试.
分别在5w, 10w, 15w,30w, 50w, 100w记录进行测试, 其中50w以内误差均小于1%, 100w以内误差小于3%:

*  5w 误差: 0.26%
*  10w 误差:0.28%
*  15w 误差:0.37%
*  30w 误差:0.23%
*  50w 误差:0.66%
*  100w 误差:2.4%

详细测试结果:
`leviathan@ubuntu:~/Documents/pika-master$ tclsh tests/test_helper.tcl --clients 1 --single` `unit/hyperloglog`

`Cleanup: may take some time... OK`
`Starting test server at port 11111`
`[ready]: 2546`
`Testing unit/hyperloglog`
`Starting ----` 
`Before Wait`
`After Wait`
`[ok]: PFADD without arguments creates an HLL value`
`[ok]: Approximated cardinality after creation is zero`
`[ok]: PFADD returns 1 when at least 1 reg was modified`
`[ok]: PFADD returns 0 when no reg was modified`
`[ok]: PFADD works with empty string (regression)`
`[ok]: PFCOUNT returns approximated cardinality of set`
`[ok]: PFMERGE results on the cardinality of union of sets`
`[ok]: PFCOUNT multiple-keys merge returns cardinality of union`
`50000 error rate: 0.0026199999999999999`
`100000 error rate: 0.0028900000000000002`
`150000 error rate: 0.0037733333333333334`
`300000 error rate: 0.0023033333333333334`
`500000 error rate: 0.0066519999999999999`
`1000000 error rate: 0.024093`
`[ok]: HYPERLOGLOG press test: 5w, 10w, 15w, 20w, 30w, 50w, 100w`
`Waiting for process 2549 to exit...`
`Waiting for process 2549 to exit...`
`[1/1 done]: unit/hyperloglog (1988 seconds)`
                   
    `The End`

`Execution time of different units:`
  `1988 seconds - unit/hyperloglog`
`\o/ All tests passed without errors!`
`Cleanup: may take some time... OK`
