### PR TITLE
workaround on compile error when jemalloc exists

### DIFF
--- a/detect_tcmalloc
+++ b/detect_tcmalloc
@@ -14,22 +14,29 @@ if test -z "$CXX"; then
     CXX=g++
 fi
 
-# Test whether tcmalloc is available
+# Test whether jemalloc is available
 if echo 'int main() {}' | $CXX $CFLAGS -x c++ - -o /dev/null \
-  -ltcmalloc 2>/dev/null; then
-    TCMALLOC_LDFLAGS=" -ltcmalloc"
-fi
+  -ljemalloc 2>/dev/null; then
+    TCMALLOC_LDFLAGS=" -ljemalloc"
+else
+  # Test whether tcmalloc is available
+  if echo 'int main() {}' | $CXX $CFLAGS -x c++ - -o /dev/null \
+    -ltcmalloc 2>/dev/null; then
+      TCMALLOC_LDFLAGS=" -ltcmalloc"
+  fi
 
-# Test whether malloc_extension is available
-$CXX $CFLAGS -x c++ - -o /dev/null -ltcmalloc 2>/dev/null  <<EOF
-  #include <gperftools/malloc_extension.h>
-  int main() {
-    MallocExtension::instance()->Initialize();;
-    return 0;
-  }
+  # Test whether malloc_extension is available
+  $CXX $CFLAGS -x c++ - -o /dev/null -ltcmalloc 2>/dev/null  <<EOF
+    #include <gperftools/malloc_extension.h>
+    int main() {
+      MallocExtension::instance()->Initialize();;
+      return 0;
+    }
 EOF
-if [ "$?" = 0 ]; then
+
+  if [ "$?" = 0 ]; then
     TCMALLOC_EXTENSION_FLAGS=" -DTCMALLOC_EXTENSION"
+  fi
 fi
 
 echo "TCMALLOC_EXTENSION_FLAGS=$TCMALLOC_EXTENSION_FLAGS" >> "$OUTPUT"


### PR DESCRIPTION
when jemalloc exists, add -ljemalloc to LDFLAGS and disable TCMALLOC_EXTENSION.