### PR TITLE
fix: slot migrate cannot operate the same name of different datatypes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
 
 addons:
   apt:
-    packages: ['zlib1g-dev', 'libbz2-dev', 'libsnappy-dev', 'curl', 'libprotobuf-dev', 'protobuf-compiler']
+    packages: ['libsnappy-dev', 'libprotobuf-dev', 'libgoogle-glog-dev']
 
 compiler:
   - gcc

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER left2right <yqzhang@easemob.com>
 RUN yum -y update && \
     yum -y install snappy-devel && \
     yum -y install protobuf-devel && \
+    yum -y install glog-devel && \
     yum -y install gcc-c++ && \
     yum -y install make && \
     yum -y install git

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,10 @@ NEMO = $(NEMO_PATH)/lib/libnemo$(DEBUG_SUFFIX).a
 ifndef GLOG_PATH
 GLOG_PATH = $(THIRD_PATH)/glog
 endif
-GLOG = $(GLOG_PATH)/.libs/libglog.so.0.0.0
+
+ifeq ($(360), 1)
+GLOG := $(GLOG_PATH)/.libs/libglog.so.0.0.0
+endif
 
 INCLUDE_PATH = -I./include \
 							 -I$(SLASH_PATH)/ \
@@ -91,16 +94,22 @@ INCLUDE_PATH = -I./include \
 							 -I$(NEMO_PATH)/include \
 							 -I$(NEMODB_PATH)/include \
 							 -I$(ROCKSDB_PATH)/ \
-							 -I$(ROCKSDB_PATH)/include \
-							 -I$(GLOG_PATH)/src/
+							 -I$(ROCKSDB_PATH)/include
+
+ifeq ($(360),1)
+INCLUDE_PATH += -I$(GLOG_PATH)/src/
+endif
 
 LIB_PATH = -L./ \
 					 -L$(SLASH_PATH)/slash/lib/ \
 					 -L$(PINK_PATH)/pink/lib/ \
 					 -L$(NEMO_PATH)/lib/ \
 					 -L$(NEMODB_PATH)/lib \
-					 -L$(ROCKSDB_PATH)/ \
-					 -L$(GLOG_PATH)/.libs/
+					 -L$(ROCKSDB_PATH)/
+
+ifeq ($(360),1)
+LIB_PATH += -L$(GLOG_PATH)/.libs/
+endif
 
 LDFLAGS += $(LIB_PATH) \
 					 -lprotobuf \

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Pika is a persistent huge storage service , compatible  with the vast majority o
 
 * snappy - a library for fast data compression
 * protobuf - google protobuf library
+* glog - google log library
 
 Upgrade your gcc to version at least 4.8 to get C++11 support.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -46,10 +46,10 @@ Pika是一个可持久化的大容量redis存储服务，兼容string、hash、l
 
 ## 编译安装
 
-1.在编译机上安装snappy，protobuf， CentOS系统可以用yum安装，Ubuntu可以用apt-get安装。如是CentOS系统，执行如下命令：
+1.在编译机上安装snappy，glog，protobuf，CentOS系统可以用yum安装，Ubuntu可以用apt-get安装。如是CentOS系统，执行如下命令：
 
 ```
-    yum install snappy-devel protobuf-devel
+    yum install snappy-devel protobuf-devel glog-devel
 ```
 
 2.安装g++(若没有安装), 在CentOS上执行如下命令：

--- a/src/pika_slot.cc
+++ b/src/pika_slot.cc
@@ -178,9 +178,9 @@ static int kvGet(const std::string key, std::string &value){
 }
 
 // delete key from db
-static int keyDel(const std::string key){
+static int keyDel(const std::string key, const char key_type){
     int64_t count = 0;
-    nemo::Status s = g_pika_server->db()->Del(key, &count);
+    nemo::Status s = g_pika_server->db()->DelSingleType(key, &count, key_type);
     if (!s.ok()) {
         if (s.IsNotFound()) {
             LOG(WARNING) << "Del key: "<< key <<" not found ";
@@ -238,7 +238,7 @@ static int migrateKv(const std::string dest_ip, const int64_t dest_port, const s
     }
 
     delete cli;
-    keyDel(key); //key already been migrated successfully, del error doesn't matter
+    keyDel(key, 'k'); //key already been migrated successfully, del error doesn't matter
     return 1;
 }
 
@@ -294,7 +294,7 @@ static int migrateHash(const std::string dest_ip, const int64_t dest_port, const
     }
 
     delete cli;
-    keyDel(key); //key already been migrated successfully, del error doesn't matter
+    keyDel(key, 'h'); //key already been migrated successfully, del error doesn't matter
     return 1;
 }
 
@@ -349,7 +349,7 @@ static int migrateList(const std::string dest_ip, const int64_t dest_port, const
     }
 
     delete cli;
-    keyDel(key); //key already been migrated successfully, del error doesn't matter
+    keyDel(key, 'l'); //key already been migrated successfully, del error doesn't matter
     return 1;
 }
 
@@ -404,7 +404,7 @@ static int migrateSet(const std::string dest_ip, const int64_t dest_port, const 
     }
 
     delete cli;
-    keyDel(key); //key already been migrated successfully, del error doesn't matter
+    keyDel(key, 's'); //key already been migrated successfully, del error doesn't matter
     return 1;
 }
 
@@ -460,7 +460,7 @@ static int migrateZset(const std::string dest_ip, const int64_t dest_port, const
     }
 
     delete cli;
-    keyDel(key);
+    keyDel(key, 'z');
     return 1;
 }
 


### PR DESCRIPTION
we use pika as a codis backend, it provides slotmigrate command to migrate slots between different pika servers.

when there're different types of data (i.e. kv and hash) have the same name (i.e. a)
for example,
set a 1
hset a b 1

then there will be both a k-v and a hash named 'a'

when slotmigrate meet this situation, it will first migrate the k-v 'a' and call Nemo::Del to del the migrated key. However, it will delete the hash 'a'.

I've modified nemo to add an interface deleting only the specified type of key (https://github.com/Qihoo360/nemo/pull/18), this pull request take usage of it to do the proper deletion.

sorry for not so familiar with PR w/ submodules if I did something wrong...