### PR TITLE
include required header - <sstream>

### DIFF
--- a/include/pika_admin.h
+++ b/include/pika_admin.h
@@ -5,6 +5,9 @@
 
 #ifndef PIKA_ADMIN_H_
 #define PIKA_ADMIN_H_
+
+#include <sstream>
+
 #include "include/pika_command.h"
 #include "include/pika_client_conn.h"
 

--- a/include/pika_hub_manager.h
+++ b/include/pika_hub_manager.h
@@ -11,6 +11,7 @@
 #include <set>
 #include <memory>
 #include <future>
+#include <sstream>
 
 #include "pink/include/server_thread.h"
 #include "pink/include/pink_thread.h"


### PR DESCRIPTION
Compile failed because of missing include \<sstream\>.
Errors like as follows:
```
/root/github/pika/src/pika_hub_manager.cc: In member function ‘std::string PikaHubManager::StatusToString()’:
/root/github/pika/src/pika_hub_manager.cc:193:21: error: aggregate ‘std::stringstream tmp_stream’ has incomplete type and cannot be defined
   std::stringstream tmp_stream;
                     ^
```