### PR TITLE
Fix async migrate

### DIFF
--- a/include/pika_slot.h
+++ b/include/pika_slot.h
@@ -8,7 +8,7 @@
 #include "strings.h"
 
 const std::string SlotKeyPrefix = "_internal:slotkey:4migrate:";
-const size_t MaxKeySendSize = 10 * 1024;
+const size_t MaxKeySendSize = 1024;
 //crc 32
 #define HASH_SLOTS_MASK 0x000003ff
 #define HASH_SLOTS_SIZE (HASH_SLOTS_MASK + 1)

--- a/include/pika_slot.h
+++ b/include/pika_slot.h
@@ -8,7 +8,7 @@
 #include "strings.h"
 
 const std::string SlotKeyPrefix = "_internal:slotkey:4migrate:";
-const size_t MaxKeySendSize = 1024;
+const size_t MaxKeySendSize = 10 * 1024;
 //crc 32
 #define HASH_SLOTS_MASK 0x000003ff
 #define HASH_SLOTS_SIZE (HASH_SLOTS_MASK + 1)

--- a/src/pika_slot.cc
+++ b/src/pika_slot.cc
@@ -16,6 +16,8 @@
 extern PikaServer *g_pika_server;
 extern PikaConf *g_pika_conf;
 
+const int asyncRecvsNum = 64;
+
 uint32_t crc32tab[256];
 void CRC32TableInit(uint32_t poly) {
     int i, j;
@@ -137,13 +139,7 @@ static int doMigrate(pink::PinkCli *cli, std::string send_str){
         LOG(WARNING) << "Slot Migrate Send error: " <<strerror(errno);
         return -1;
     }
-    // Recv
-    s = cli->Recv(NULL);
-    if (!s.ok()) {
-        LOG(WARNING) << "Slot Migrate Recv error: " <<strerror(errno);
-        return -1;
-    }
-    return 0;
+    return 1;
 }
 
 //do migrate cli auth
@@ -218,19 +214,20 @@ static int migrateKeyTTl(pink::PinkCli *cli, const std::string key){
         if (doMigrate(cli, send_str) < 0){
             return -1;
         }
-
+        return 1;
     }
     return 0;
 }
 
 // migrate one kv key
 static int migrateKv(pink::PinkCli *cli, const std::string key){
+    int r, ret = 0;
     std::string value;
     if (kvGet(key, value) < 0){
-      return -1;
+        return -1;
     }
     if (value==""){
-      return 0;
+        return 0;
     }
 
     pink::RedisCmdArgsType argv;
@@ -241,15 +238,19 @@ static int migrateKv(pink::PinkCli *cli, const std::string key){
     pink::SerializeRedisCommand(argv, &send_str);
 
     if (doMigrate(cli, send_str) < 0){
-      return -1;
+        return -1;
+    } else {
+        ret++;
     }
 
-    if (migrateKeyTTl(cli, key) < 0){
+    if ((r = migrateKeyTTl(cli, key)) < 0){
         return -1;
+    } else {
+        ret += r;
     }
 
     KeyDelete(key, 'k'); //key already been migrated successfully, del error doesn't matter
-    return 1;
+    return ret;
 }
 
 //get all hash field and values
@@ -269,6 +270,7 @@ static int hashGetall(const std::string key, std::vector<nemo::FV> &fvs){
 
 // migrate one hash key
 static int migrateHash(pink::PinkCli *cli, const std::string key){
+    int r, ret = 0;
     std::vector<nemo::FV> fvs;
     if (hashGetall(key, fvs) < 0){
         return -1;
@@ -295,15 +297,19 @@ static int migrateHash(pink::PinkCli *cli, const std::string key){
         pink::SerializeRedisCommand(argv, &send_str);
         if (doMigrate(cli, send_str) < 0){
             return -1;
+        } else {
+            ret++;
         }
     }
 
-    if (migrateKeyTTl(cli, key) < 0){
+    if ((r = migrateKeyTTl(cli, key)) < 0){
         return -1;
+    } else {
+        ret += r;
     }
 
     KeyDelete(key, 'h'); //key already been migrated successfully, del error doesn't matter
-    return 1;
+    return ret;
 }
 
 // get list key all values
@@ -323,6 +329,7 @@ static int listGetall(const std::string key, std::vector<nemo::IV> &ivs){
 
 // migrate one list key
 static int migrateList(pink::PinkCli *cli, const std::string key){
+    int r, ret = 0;
     std::vector<nemo::IV> ivs;
     if (listGetall(key, ivs) < 0){
         return -1;
@@ -348,15 +355,19 @@ static int migrateList(pink::PinkCli *cli, const std::string key){
         pink::SerializeRedisCommand(argv, &send_str);
         if (doMigrate(cli, send_str) < 0){
             return -1;
+        } else {
+            ret++;
         }
     }
 
-    if (migrateKeyTTl(cli, key) < 0){
+    if ((r = migrateKeyTTl(cli, key)) < 0){
         return -1;
+    } else {
+        ret += r;
     }
 
     KeyDelete(key, 'l'); //key already been migrated successfully, del error doesn't matter
-    return 1;
+    return ret;
 }
 
 // get set key all values
@@ -376,6 +387,7 @@ static int setGetall(const std::string key, std::vector<std::string> &members){
 
 // migrate one set key
 static int migrateSet(pink::PinkCli *cli, const std::string key){
+    int r, ret = 0;
     std::vector<std::string> members;
     if (setGetall(key, members) < 0){
         return -1;
@@ -401,15 +413,19 @@ static int migrateSet(pink::PinkCli *cli, const std::string key){
         pink::SerializeRedisCommand(argv, &send_str);
         if (doMigrate(cli, send_str) < 0){
             return -1;
+        } else {
+            ret++;
         }
     }
 
-    if (migrateKeyTTl(cli, key) < 0){
+    if ((r = migrateKeyTTl(cli, key)) < 0){
         return -1;
+    } else {
+        ret += r;
     }
 
     KeyDelete(key, 's'); //key already been migrated successfully, del error doesn't matter
-    return 1;
+    return ret;
 }
 
 // get one zset key all values
@@ -429,6 +445,7 @@ static int zsetGetall(const std::string key, std::vector<nemo::SM> &sms){
 
 // migrate zset key
 static int migrateZset(pink::PinkCli *cli, const std::string key){
+    int r, ret = 0;
     std::vector<nemo::SM> sms;
     if (zsetGetall(key, sms) < 0){
         return -1;
@@ -455,46 +472,51 @@ static int migrateZset(pink::PinkCli *cli, const std::string key){
         pink::SerializeRedisCommand(argv, &send_str);
         if (doMigrate(cli, send_str) < 0){
             return -1;
+        } else {
+            ret++;
         }
     }
 
-    if (migrateKeyTTl(cli, key) < 0){
+    if ((r = migrateKeyTTl(cli, key)) < 0){
         return -1;
+    } else {
+        ret += r;
     }
 
     KeyDelete(key, 'z');
-    return 1;
+    return ret;
 }
 
 // migrate key
 static int MigrateOneKey(pink::PinkCli *cli, const std::string key, const char key_type){
+    int ret;
     switch (key_type) {
         case 'k':
-            if (migrateKv(cli, key) < 0){
+            if ((ret = migrateKv(cli, key)) < 0){
                 SlotKeyAdd("k", key);
                 return -1;
             }
             break;
         case 'h':
-            if (migrateHash(cli, key) < 0){
+            if ((ret = migrateHash(cli, key)) < 0){
                 SlotKeyAdd("h", key);
                 return -1;
             }
             break;
         case 'l':
-            if (migrateList(cli, key) < 0){
+            if ((ret = migrateList(cli, key)) < 0){
                 SlotKeyAdd("l", key);
                 return -1;
             }
             break;
         case 's':
-            if (migrateSet(cli, key) < 0){
+            if ((ret = migrateSet(cli, key)) < 0){
                 SlotKeyAdd("s", key);
                 return -1;
             }
             break;
         case 'z':
-            if (migrateZset(cli, key) < 0){
+            if ((ret = migrateZset(cli, key)) < 0){
                 SlotKeyAdd("z", key);
                 return -1;
             }
@@ -503,7 +525,7 @@ static int MigrateOneKey(pink::PinkCli *cli, const std::string key, const char k
             return -1;
             break;
     }
-    return 0;
+    return ret;
 }
 
 // check slotkey remaind keys number
@@ -1387,18 +1409,28 @@ void* SlotsMgrtSenderThread::ThreadMain() {
 
                 iter = migrating_batch_.begin();
                 while(iter != migrating_batch_.end()) {
+                    size_t j = 0;
                     slash::RWLock lb(&rwlock_batch_, false);
-                    for (; iter != migrating_batch_.end(); iter++) {
-                        if (MigrateOneKey(cli_, iter->second, iter->first) < 0){
+                    for (int r; iter != migrating_batch_.end() && (j < asyncRecvsNum); iter++) {
+                        if ((r = MigrateOneKey(cli_, iter->second, iter->first)) < 0){
                             LOG(WARNING) << "Migrate batch key: " << iter->second <<" error: ";
                             slotsmgrt_cond_.Signal();
                             is_migrating_ = false;
                             should_exit_ = true;
                             goto migrate_end;
+                        } else {
+                            j += r;
                         }
                         moved_keys_num_++;
                         moved_keys_all_++;
                         remained_keys_num_--;
+                    }
+                    for (; j>0; j--) {
+                        slash::Status s;
+                        s = cli_->Recv(NULL);
+                        if (!s.ok()) {
+                            break;
+                        }
                     }
                 }
 


### PR DESCRIPTION
this PR is based on https://github.com/Qihoo360/pika/pull/235 and improve it by pipelining recv() to improve migration performance.

I changed the return value of functions for migrating non-KV keys to represent the number of cli->Send() calling, and thereafter identical number of Recv() are called.

@left2right @KernelMaker 


Known issue: (may be fixed when I have time in the next weeks/months...)
0. KeyDelete() does NOT write binlog, the deletions aren't propagated to the slaves correctly.
1. slotscleanup command is not read-only but is allowed to run on a read-only slave.
