### PR TITLE
Geo support for pika 3.0

### DIFF
--- a/include/pika_geo.h
+++ b/include/pika_geo.h
@@ -1,0 +1,133 @@
+// Copyright (c) 2015-present, Qihoo, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#ifndef PIKA_GEO_H_
+#define PIKA_GEO_H_
+#include "include/pika_command.h"
+#include "nemo.h"
+
+
+/*
+ * zset
+ */
+ enum Sort
+{
+  Unsort,	//default
+  Asc,
+  Desc
+};
+
+ struct GeoPoint {
+  std::string member;
+  double longitude;
+  double latitude;
+};
+
+ struct NeighborPoint{
+   std::string member;
+   double score;
+   double distance;
+ };
+
+ struct GeoRange {
+  std::string member;
+  double longitude;
+  double latitude;
+  double distance;
+  std::string unit;
+  bool withdist;
+  bool withhash;
+  bool withcoord;
+  int option_num;
+  bool count;
+  int count_limit;
+  bool store;
+  bool storedist;
+  std::string storekey;
+  Sort sort;
+ };
+
+class GeoAddCmd : public Cmd {
+public:
+  GeoAddCmd() {}
+  virtual void Do();
+private:
+  std::string key_;
+  std::vector<GeoPoint> pos_;
+  virtual void DoInitial(PikaCmdArgsType &argvs, const CmdInfo* const ptr_info);
+};
+
+class GeoPosCmd : public Cmd {
+public:
+  GeoPosCmd() {}
+  virtual void Do();
+private:
+  std::string key_;
+  std::vector<std::string> member_;
+  virtual void DoInitial(PikaCmdArgsType &argvs, const CmdInfo* const ptr_info);
+};
+
+class GeoDistCmd : public Cmd {
+public:
+  GeoDistCmd() {}
+  virtual void Do();
+private:
+  std::string key_, first_pos_, second_pos_, unit_;
+  virtual void DoInitial(PikaCmdArgsType &argvs, const CmdInfo* const ptr_info);
+};
+
+class GeoHashCmd : public Cmd {
+public:
+  GeoHashCmd() {}
+  virtual void Do();
+private:
+  std::string key_;
+  std::vector<std::string> member_;
+  virtual void DoInitial(PikaCmdArgsType &argvs, const CmdInfo* const ptr_info);
+};
+
+class GeoRadiusCmd : public Cmd {
+public:
+  GeoRadiusCmd() {}
+  virtual void Do();
+private:
+  std::string key_;
+  GeoRange range_;
+  virtual void DoInitial(PikaCmdArgsType &argvs, const CmdInfo* const ptr_info);
+  virtual void Clear() {
+    range_.withdist = false;
+    range_.withcoord = false;
+    range_.withhash = false;
+    range_.count = false;
+    range_.store = false;
+    range_.storedist = false;
+    range_.option_num = 0;
+    range_.count_limit = 0;
+    range_.sort = Unsort;
+  }
+};
+
+class GeoRadiusByMemberCmd : public Cmd {
+public:
+  GeoRadiusByMemberCmd() {}
+  virtual void Do();
+private:
+  std::string key_;
+  GeoRange range_;
+  virtual void DoInitial(PikaCmdArgsType &argvs, const CmdInfo* const ptr_info);
+  virtual void Clear() {
+    range_.withdist = false;
+    range_.withcoord = false;
+    range_.withhash = false;
+    range_.count = false;
+    range_.store = false;
+    range_.storedist = false;
+    range_.option_num = 0;
+    range_.count_limit = 0;
+    range_.sort = Unsort;
+  }
+};
+
+#endif

--- a/include/pika_geo.h
+++ b/include/pika_geo.h
@@ -6,8 +6,6 @@
 #ifndef PIKA_GEO_H_
 #define PIKA_GEO_H_
 #include "include/pika_command.h"
-#include "nemo.h"
-
 
 /*
  * zset

--- a/include/pika_geohash.h
+++ b/include/pika_geohash.h
@@ -44,7 +44,7 @@ extern "C" {
 #define RANGEISZERO(r) (!(r).max && !(r).min)
 #define RANGEPISZERO(r) (r == NULL || RANGEISZERO(*r))
 
-#define GEO_STEP_MAX 18 /* 26*2 = 52 bits. */
+#define GEO_STEP_MAX 26 /* 26*2 = 52 bits. */
 
 /* Limits from EPSG:900913 / EPSG:3785 / OSGEO:41001 */
 #define GEO_LAT_MIN -85.05112878
@@ -115,4 +115,4 @@ void geohashNeighbors(const GeoHashBits *hash, GeoHashNeighbors *neighbors);
 #if defined(__cplusplus)
 }
 #endif
-#endif /* GEOHASH_H_ */
+#endif /* PIKA_GEOHASH_H_ */

--- a/include/pika_geohash.h
+++ b/include/pika_geohash.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2013-2014, yinqiwen <yinqiwen@gmail.com>
+ * Copyright (c) 2014, Matt Stancliff <matt@genges.com>.
+ * Copyright (c) 2015, Salvatore Sanfilippo <antirez@gmail.com>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of Redis nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PIKA_GEOHASH_H_
+#define PIKA_GEOHASH_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#define HASHISZERO(r) (!(r).bits && !(r).step)
+#define RANGEISZERO(r) (!(r).max && !(r).min)
+#define RANGEPISZERO(r) (r == NULL || RANGEISZERO(*r))
+
+#define GEO_STEP_MAX 18 /* 26*2 = 52 bits. */
+
+/* Limits from EPSG:900913 / EPSG:3785 / OSGEO:41001 */
+#define GEO_LAT_MIN -85.05112878
+#define GEO_LAT_MAX 85.05112878
+#define GEO_LONG_MIN -180
+#define GEO_LONG_MAX 180
+
+typedef enum {
+    GEOHASH_NORTH = 0,
+    GEOHASH_EAST,
+    GEOHASH_WEST,
+    GEOHASH_SOUTH,
+    GEOHASH_SOUTH_WEST,
+    GEOHASH_SOUTH_EAST,
+    GEOHASH_NORT_WEST,
+    GEOHASH_NORT_EAST
+} GeoDirection;
+
+typedef struct {
+    uint64_t bits;
+    uint8_t step;
+} GeoHashBits;
+
+typedef struct {
+    double min;
+    double max;
+} GeoHashRange;
+
+typedef struct {
+    GeoHashBits hash;
+    GeoHashRange longitude;
+    GeoHashRange latitude;
+} GeoHashArea;
+
+typedef struct {
+    GeoHashBits north;
+    GeoHashBits east;
+    GeoHashBits west;
+    GeoHashBits south;
+    GeoHashBits north_east;
+    GeoHashBits south_east;
+    GeoHashBits north_west;
+    GeoHashBits south_west;
+} GeoHashNeighbors;
+
+/*
+ * 0:success
+ * -1:failed
+ */
+void geohashGetCoordRange(GeoHashRange *long_range, GeoHashRange *lat_range);
+int geohashEncode(const GeoHashRange *long_range, const GeoHashRange *lat_range,
+                  double longitude, double latitude, uint8_t step,
+                  GeoHashBits *hash);
+int geohashEncodeType(double longitude, double latitude,
+                      uint8_t step, GeoHashBits *hash);
+int geohashEncodeWGS84(double longitude, double latitude, uint8_t step,
+                       GeoHashBits *hash);
+int geohashDecode(const GeoHashRange long_range, const GeoHashRange lat_range,
+                  const GeoHashBits hash, GeoHashArea *area);
+int geohashDecodeType(const GeoHashBits hash, GeoHashArea *area);
+int geohashDecodeWGS84(const GeoHashBits hash, GeoHashArea *area);
+int geohashDecodeAreaToLongLat(const GeoHashArea *area, double *xy);
+int geohashDecodeToLongLatType(const GeoHashBits hash, double *xy);
+int geohashDecodeToLongLatWGS84(const GeoHashBits hash, double *xy);
+int geohashDecodeToLongLatMercator(const GeoHashBits hash, double *xy);
+void geohashNeighbors(const GeoHashBits *hash, GeoHashNeighbors *neighbors);
+
+#if defined(__cplusplus)
+}
+#endif
+#endif /* GEOHASH_H_ */

--- a/include/pika_geohash_helper.h
+++ b/include/pika_geohash_helper.h
@@ -29,8 +29,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef PIKA_GEOHASH_HELPER_H_
-#define PIKA_GEOHASH_HELPER_H_
+#ifndef PIKA_GEOHASH_HELPER_HPP_
+#define PIKA_GEOHASH_HELPER_HPP_
 
 #include "include/pika_geohash.h"
 
@@ -67,4 +67,4 @@ int geohashGetDistanceIfInRadiusWGS84(double x1, double y1, double x2,
                                       double y2, double radius,
                                       double *distance);
 
-#endif /* GEOHASH_HELPER_HPP_ */
+#endif /* PIKA_GEOHASH_HELPER_HPP_ */

--- a/include/pika_geohash_helper.h
+++ b/include/pika_geohash_helper.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2013-2014, yinqiwen <yinqiwen@gmail.com>
+ * Copyright (c) 2014, Matt Stancliff <matt@genges.com>.
+ * Copyright (c) 2015, Salvatore Sanfilippo <antirez@gmail.com>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of Redis nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PIKA_GEOHASH_HELPER_H_
+#define PIKA_GEOHASH_HELPER_H_
+
+#include "include/pika_geohash.h"
+
+#define GZERO(s) s.bits = s.step = 0;
+#define GISZERO(s) (!s.bits && !s.step)
+#define GISNOTZERO(s) (s.bits || s.step)
+
+typedef uint64_t GeoHashFix52Bits;
+typedef uint64_t GeoHashVarBits;
+
+typedef struct {
+    GeoHashBits hash;
+    GeoHashArea area;
+    GeoHashNeighbors neighbors;
+} GeoHashRadius;
+
+int GeoHashBitsComparator(const GeoHashBits *a, const GeoHashBits *b);
+uint8_t geohashEstimateStepsByRadius(double range_meters, double lat);
+int geohashBoundingBox(double longitude, double latitude, double radius_meters,
+                        double *bounds);
+GeoHashRadius geohashGetAreasByRadius(double longitude,
+                                      double latitude, double radius_meters);
+GeoHashRadius geohashGetAreasByRadiusWGS84(double longitude, double latitude,
+                                           double radius_meters);
+GeoHashRadius geohashGetAreasByRadiusMercator(double longitude, double latitude,
+                                              double radius_meters);
+GeoHashFix52Bits geohashAlign52Bits(const GeoHashBits hash);
+double geohashGetDistance(double lon1d, double lat1d,
+                          double lon2d, double lat2d);
+int geohashGetDistanceIfInRadius(double x1, double y1,
+                                 double x2, double y2, double radius,
+                                 double *distance);
+int geohashGetDistanceIfInRadiusWGS84(double x1, double y1, double x2,
+                                      double y2, double radius,
+                                      double *distance);
+
+#endif /* GEOHASH_HELPER_HPP_ */

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -377,6 +377,26 @@ void InitCmdInfoTable() {
   CmdInfo* pfmergeptr = new CmdInfo(kCmdNamePfMerge, -3, kCmdFlagsWrite | kCmdFlagsHyperLogLog);
   cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNamePfMerge, pfmergeptr));
 
+  //GEO
+  ////GeoAdd
+  CmdInfo* geoaddptr = new CmdInfo(kCmdNameGeoAdd, -5, kCmdFlagsWrite | kCmdFlagsGeo);
+  cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNameGeoAdd, geoaddptr));
+  ////GeoPos
+  CmdInfo* geoposptr = new CmdInfo(kCmdNameGeoPos, -2, kCmdFlagsRead | kCmdFlagsGeo);
+  cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNameGeoPos, geoposptr));
+  ////GeoDist
+  CmdInfo* geodistptr = new CmdInfo(kCmdNameGeoDist, -4, kCmdFlagsRead | kCmdFlagsGeo);
+  cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNameGeoDist, geodistptr));
+  ////GeoHash
+  CmdInfo* geohashptr = new CmdInfo(kCmdNameGeoHash, -2, kCmdFlagsRead | kCmdFlagsGeo);
+  cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNameGeoHash, geohashptr));
+  ////GeoRadius
+  CmdInfo* georadiusptr = new CmdInfo(kCmdNameGeoRadius, -6, kCmdFlagsRead | kCmdFlagsGeo);
+  cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNameGeoRadius, georadiusptr));
+  ////GeoRadiusByMember
+  CmdInfo* georadiusbymemberptr = new CmdInfo(kCmdNameGeoRadiusByMember, -5, kCmdFlagsRead | kCmdFlagsGeo);
+  cmd_infos.insert(std::pair<std::string, CmdInfo*>(kCmdNameGeoRadiusByMember, georadiusbymemberptr));
+
   //Pub/Sub
   //Publish
   CmdInfo* publishptr = new CmdInfo(kCmdNamePublish, 3, kCmdFlagsRead | kCmdFlagsPubSub);

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -11,6 +11,7 @@
 #include "include/pika_zset.h"
 #include "include/pika_bit.h"
 #include "include/pika_hyperloglog.h"
+#include "include/pika_geo.h"
 #include "include/pika_pubsub.h"
 
 static std::unordered_map<std::string, CmdInfo*> cmd_infos(300);    /* Table for CmdInfo */
@@ -789,6 +790,26 @@ void InitCmdTable(std::unordered_map<std::string, Cmd*> *cmd_table) {
   ////pfmergeCmd
   Cmd * pfmergeptr = new PfMergeCmd();
   cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNamePfMerge, pfmergeptr));
+
+  //GEO
+  ////GepAdd
+  Cmd * geoaddptr = new GeoAddCmd();
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameGeoAdd, geoaddptr));
+  ////GeoPos
+  Cmd * geoposptr = new GeoPosCmd();
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameGeoPos, geoposptr));
+  ////GeoDist
+  Cmd * geodistptr = new GeoDistCmd();
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameGeoDist, geodistptr));
+  ////GeoHash
+  Cmd * geohashptr = new GeoHashCmd();
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameGeoHash, geohashptr));
+  ////GeoRadius
+  Cmd * georadiusptr = new GeoRadiusCmd();
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameGeoRadius, georadiusptr));
+  ////GeoRadiusByMember
+  Cmd * georadiusbymemberptr = new GeoRadiusByMemberCmd();
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameGeoRadiusByMember, georadiusbymemberptr));
 
   //PubSub
   ////Publish

--- a/src/pika_geo.cc
+++ b/src/pika_geo.cc
@@ -1,0 +1,561 @@
+// Copyright (c) 2015-present, Qihoo, Inc.  All rights reserved.
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <sstream>
+#include <algorithm>
+
+#include "slash/include/slash_string.h"
+#include "nemo.h"
+#include "include/pika_geo.h"
+#include "include/pika_server.h"
+#include "include/pika_geohash_helper.h"
+
+extern PikaServer *g_pika_server;
+
+void GeoAddCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info) {
+  if (!ptr_info->CheckArg(argv.size())) {
+    res_.SetRes(CmdRes::kWrongNum, kCmdNameGeoAdd);
+    return;
+  }
+  size_t argc = argv.size();
+  if ((argc - 2) % 3 != 0) {
+    res_.SetRes(CmdRes::kWrongNum, kCmdNameGeoAdd);
+    return;
+  }
+  key_ = argv[1];
+  pos_.clear();
+  size_t index = 2;
+  for (; index < argc; index += 3) {
+    struct GeoPoint point;
+    double longitude, latitude;
+    if (!slash::string2d(argv[index].data(), argv[index].size(), &longitude)) {
+      res_.SetRes(CmdRes::kInvalidFloat);
+      return;
+    }
+    if (!slash::string2d(argv[index+1].data(), argv[index+1].size(), &latitude)) {
+      res_.SetRes(CmdRes::kInvalidFloat);
+      return;
+    }
+    point.member = argv[index+2];
+    point.longitude = longitude;
+    point.latitude = latitude;
+    pos_.push_back(point);
+  }
+  return;
+}
+
+void GeoAddCmd::Do() {
+  nemo::Status s;
+  int64_t count = 0, ret;
+  const std::shared_ptr<nemo::Nemo> db = g_pika_server->db();
+  std::vector<GeoPoint>::const_iterator iter = pos_.begin();
+  for (; iter != pos_.end(); iter++) {
+    // Convert coordinates to geohash
+    GeoHashBits hash;
+    geohashEncodeWGS84(iter->longitude, iter->latitude, GEO_STEP_MAX, &hash);
+    GeoHashFix52Bits bits = geohashAlign52Bits(hash);
+    // Convert uint64 to double
+    double score;
+    std::string str_bits = std::to_string(bits);
+    slash::string2d(str_bits.data(), str_bits.size(), &score);
+    s = db->ZAdd(key_, score, iter->member, &ret); 
+    if (s.ok()) {
+      count += ret;
+    } else {
+      res_.SetRes(CmdRes::kErrOther, s.ToString());
+      return;
+    }
+  }
+  res_.AppendInteger(count);
+  return;
+}
+
+void GeoPosCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info) {
+  if (!ptr_info->CheckArg(argv.size())) {
+    res_.SetRes(CmdRes::kWrongNum, kCmdNameGeoPos);
+    return;
+  }
+  key_ = argv[1];
+  member_.clear();
+  size_t pos = 2;
+  while (pos < argv.size()) {
+    member_.push_back(argv[pos++]);
+  }
+}
+
+void GeoPosCmd::Do() {
+  double score;
+  res_.AppendArrayLen(member_.size());
+  for (auto v : member_) {
+    nemo::Status s = g_pika_server->db()->ZScore(key_, v, &score);
+    if (s.ok()) {
+      double xy[2];
+      GeoHashBits hash = { .bits = (uint64_t)score, .step = GEO_STEP_MAX };
+      geohashDecodeToLongLatWGS84(hash, xy);
+
+      res_.AppendArrayLen(2);
+      char longitude[32];
+      int64_t len = slash::d2string(longitude, sizeof(longitude), xy[0]);
+      res_.AppendStringLen(len);
+      res_.AppendContent(longitude);
+
+      char latitude[32];
+      len = slash::d2string(latitude, sizeof(latitude), xy[1]);
+      res_.AppendStringLen(len);
+      res_.AppendContent(latitude);
+    
+    } else if (s.IsNotFound()) {
+      res_.AppendStringLen(-1);
+      continue;
+    } else {
+      res_.SetRes(CmdRes::kErrOther, s.ToString());
+      continue;	
+    }
+  }
+}
+
+static double length_converter(double meters, const std::string & unit) {
+  if (unit == "m") {
+    return meters;
+  } else if (unit == "km") {
+    return meters / 1000;
+  } else if (unit == "ft") {
+    return meters / 0.3048;
+  } else if (unit == "mi") {
+    return meters / 1609.34;
+  } else {
+    return -1;
+  }
+}
+
+static bool check_unit(const std::string & unit) {
+  if (unit == "m" || unit == "km" || unit == "ft" || unit == "mi") {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void GeoDistCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info) {
+  if (!ptr_info->CheckArg(argv.size())) {
+    res_.SetRes(CmdRes::kWrongNum, kCmdNameGeoDist);
+    return;
+  }
+  if (argv.size() < 4) {
+    res_.SetRes(CmdRes::kWrongNum, kCmdNameGeoDist);
+    return;
+  } else if (argv.size() > 5) {
+    res_.SetRes(CmdRes::kSyntaxErr);
+    return;
+  }
+  key_ = argv[1];
+  first_pos_ = argv[2];
+  second_pos_ = argv[3];
+  if (argv.size() == 5) {
+    unit_ = argv[4];
+  } else {
+    unit_ = "m";
+  }
+  if (!check_unit(unit_)) {
+    res_.SetRes(CmdRes::kErrOther, "unsupported unit provided. please use m, km, ft, mi");
+    return;
+  }
+}
+
+void GeoDistCmd::Do() {
+  double first_score, second_score, first_xy[2], second_xy[2];
+  nemo::Status s = g_pika_server->db()->ZScore(key_, first_pos_, &first_score);
+  if (s.ok()) {
+    GeoHashBits hash = { .bits = (uint64_t)first_score, .step = GEO_STEP_MAX };
+    geohashDecodeToLongLatWGS84(hash, first_xy);
+  } else if (s.IsNotFound()) {
+    res_.AppendStringLen(-1);
+    return;
+  } else {
+    res_.SetRes(CmdRes::kErrOther, s.ToString());
+    return;	
+  }
+
+  s = g_pika_server->db()->ZScore(key_, second_pos_, &second_score);
+  if (s.ok()) {
+    GeoHashBits hash = { .bits = (uint64_t)second_score, .step = GEO_STEP_MAX };
+    geohashDecodeToLongLatWGS84(hash, second_xy);
+  } else if (s.IsNotFound()) {
+    res_.AppendStringLen(-1);
+    return;
+  } else {
+    res_.SetRes(CmdRes::kErrOther, s.ToString());
+    return;	
+  }
+
+  double distance = geohashGetDistance(first_xy[0], first_xy[1], second_xy[0], second_xy[1]);
+  distance = length_converter(distance, unit_);
+  char buf[32];
+  sprintf(buf, "%.4f", distance);
+  res_.AppendStringLen(strlen(buf));
+  res_.AppendContent(buf);
+}
+
+void GeoHashCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info) {
+  if (!ptr_info->CheckArg(argv.size())) {
+    res_.SetRes(CmdRes::kWrongNum, kCmdNameGeoHash);
+    return;
+  }
+  key_ = argv[1];
+  member_.clear();
+  size_t pos = 2;
+  while (pos < argv.size()) {
+    member_.push_back(argv[pos++]);
+  }
+}
+
+void GeoHashCmd::Do() {
+  const char * geoalphabet= "0123456789bcdefghjkmnpqrstuvwxyz";
+  res_.AppendArrayLen(member_.size());
+  for (auto v : member_) {
+    double score;
+    nemo::Status s = g_pika_server->db()->ZScore(key_, v, &score);
+    if (s.ok()) {
+      double xy[2];
+      GeoHashBits hash = { .bits = (uint64_t)score, .step = GEO_STEP_MAX };
+      geohashDecodeToLongLatWGS84(hash, xy);
+      GeoHashRange r[2];
+      GeoHashBits encode_hash;
+      r[0].min = -180;
+      r[0].max = 180;
+      r[1].min = -90;
+      r[1].max = 90;
+      geohashEncode(&r[0], &r[1], xy[0], xy[1], 26, &encode_hash);
+
+      char buf[12];
+      int i;
+      for (i = 0; i < 11; i++) {
+      	int idx = (encode_hash.bits >> (52-((i+1)*5))) & 0x1f;
+        buf[i] = geoalphabet[idx];
+      }
+      buf[11] = '\0';
+      res_.AppendStringLen(11);
+      res_.AppendContent(buf);
+      continue;
+    } else if (s.IsNotFound()) {
+      res_.AppendStringLen(-1);
+      continue;
+    } else {
+      res_.SetRes(CmdRes::kErrOther, s.ToString());
+      continue;	
+    }
+  }
+}
+
+static bool sort_distance_asc(const NeighborPoint & pos1, const NeighborPoint & pos2) {
+  return pos1.distance < pos2.distance;
+}
+
+static bool sort_distance_desc(const NeighborPoint & pos1, const NeighborPoint & pos2) {
+  return pos1.distance > pos2.distance;
+}
+
+static void GetAllNeighbors(std::string & key, GeoRange & range, CmdRes & res) {
+  nemo::Status s;
+  double longitude = range.longitude, latitude = range.latitude, distance = range.distance;
+  int count_limit = 0;
+  // Convert other units to meters
+  if (range.unit == "m") {
+    distance = distance;
+  } else if (range.unit == "km") {
+    distance = distance * 1000;
+  } else if (range.unit == "ft") {
+    distance = distance * 0.3048;
+  } else if (range.unit == "mi") {
+    distance = distance * 1609.34;
+  } else {
+    distance = -1;
+  }
+  // Search the zset for all matching points
+  GeoHashRadius georadius = geohashGetAreasByRadiusWGS84(longitude, latitude, distance);
+  GeoHashBits neighbors[9];
+  neighbors[0] = georadius.hash;
+  neighbors[1] = georadius.neighbors.north;
+  neighbors[2] = georadius.neighbors.south;
+  neighbors[3] = georadius.neighbors.east;
+  neighbors[4] = georadius.neighbors.west;
+  neighbors[5] = georadius.neighbors.north_east;
+  neighbors[6] = georadius.neighbors.north_west;
+  neighbors[7] = georadius.neighbors.south_east;
+  neighbors[8] = georadius.neighbors.south_west;
+
+  // For each neighbor, get all the matching
+  // members and add them to the potential result list.
+  std::vector<NeighborPoint> result;
+  int last_processed = 0;
+  for (size_t i = 0; i < sizeof(neighbors) / sizeof(*neighbors); i++) {
+    GeoHashFix52Bits min, max;
+    if (HASHISZERO(neighbors[i]))
+      continue;
+    min = geohashAlign52Bits(neighbors[i]);
+    neighbors[i].bits++;
+    max = geohashAlign52Bits(neighbors[i]);
+    // When a huge Radius (in the 5000 km range or more) is used,
+    // adjacent neighbors can be the same, so need to remove duplicated elements
+    if(last_processed && neighbors[i].bits == neighbors[last_processed].bits && neighbors[i].step == neighbors[last_processed].step) {
+	continue;
+    }
+    std::vector<nemo::SM> sm_v;
+    s = g_pika_server->db()->ZRangebyscore(key, (double)min, (double)max, sm_v, false, false);
+    if (!s.ok()) {
+      res.SetRes(CmdRes::kErrOther, s.ToString());
+      return;
+    }
+    // Insert into result only if the point is within the search area.
+    for (size_t i = 0; i < sm_v.size(); ++i) {
+      double xy[2], real_distance;
+      GeoHashBits hash = { .bits = (uint64_t)sm_v[i].score, .step = GEO_STEP_MAX };
+      geohashDecodeToLongLatWGS84(hash, xy);
+      if(geohashGetDistanceIfInRadiusWGS84(longitude, latitude, xy[0], xy[1], distance, &real_distance)) {
+        NeighborPoint item;
+        item.member = sm_v[i].member;
+        item.score = sm_v[i].score;
+        item.distance = real_distance;
+        result.push_back(item);
+      }
+    }
+    last_processed = i;
+  }
+  
+  // If using the count opiton
+  if (range.count) {
+    count_limit = static_cast<int>(result.size()) < range.count_limit ? result.size() : range.count_limit;
+  } else {
+    count_limit = result.size();
+  }
+  // If using sort option
+  if (range.sort == Asc) {
+    std::sort(result.begin(), result.end(), sort_distance_asc);
+  } else if(range.sort == Desc) {
+    std::sort(result.begin(), result.end(), sort_distance_desc);
+  }
+  
+  if (range.store || range.storedist) {
+    // Target key, create a sorted set with the results.
+    const std::shared_ptr<nemo::Nemo> db = g_pika_server->db();
+    int64_t ret;
+    for (int i = 0; i < count_limit; ++i) {
+      double distance = length_converter(result[i].distance, range.unit);
+      double score = range.store ? result[i].score : distance; 
+      s = db->ZAdd(range.storekey, score, result[i].member, &ret); 
+      if (!s.ok()) {
+        res.SetRes(CmdRes::kErrOther, s.ToString());
+        return;
+      }
+    }
+    res.AppendInteger(count_limit);
+    return;
+  } else {
+    // No target key, return results to user.
+    
+    // For each the result
+    res.AppendArrayLen(count_limit);
+    for (int i = 0; i < count_limit; ++i) {
+      if (range.option_num != 0) {
+        res.AppendArrayLen(range.option_num+1);
+      }
+      // Member
+      res.AppendStringLen(result[i].member.size());
+      res.AppendContent(result[i].member);
+    
+      // If using withdist option
+      if (range.withdist) {  
+        double xy[2];
+        GeoHashBits hash = { .bits = (uint64_t)result[i].score, .step = GEO_STEP_MAX };
+        geohashDecodeToLongLatWGS84(hash, xy);
+        double distance = geohashGetDistance(longitude, latitude, xy[0], xy[1]);
+        distance = length_converter(distance, range.unit);
+	char buf[32];
+	sprintf(buf, "%.4f", distance);
+	res.AppendStringLen(strlen(buf));
+        res.AppendContent(buf);
+      }
+      // If using withcoord option
+      if (range.withcoord) {
+        res.AppendArrayLen(2);  
+        double xy[2];
+        GeoHashBits hash = { .bits = (uint64_t)result[i].score, .step = GEO_STEP_MAX };
+        geohashDecodeToLongLatWGS84(hash, xy);
+
+        char longitude[32];
+        int64_t len = slash::d2string(longitude, sizeof(longitude), xy[0]);
+        res.AppendStringLen(len);
+        res.AppendContent(longitude);
+
+        char latitude[32];
+        len = slash::d2string(latitude, sizeof(latitude), xy[1]);
+        res.AppendStringLen(len);
+        res.AppendContent(latitude);
+      }
+      // If using withhash option
+      if (range.withhash) {
+        char buf[32];
+        int64_t len = slash::d2string(buf, sizeof(buf), result[i].score);
+        res.AppendStringLen(len);
+        res.AppendContent(buf);
+      }
+    }
+  }
+}
+
+void GeoRadiusCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info) {
+  if (!ptr_info->CheckArg(argv.size())) {
+    res_.SetRes(CmdRes::kWrongNum, kCmdNameGeoRadius);
+    return;
+  }
+  key_ = argv[1];
+  slash::string2d(argv[2].data(), argv[2].size(), &range_.longitude);
+  slash::string2d(argv[3].data(), argv[3].size(), &range_.latitude);
+  slash::string2d(argv[4].data(), argv[4].size(), &range_.distance);
+  range_.unit = argv[5];
+  if (!check_unit(range_.unit)) {
+    res_.SetRes(CmdRes::kErrOther, "unsupported unit provided. please use m, km, ft, mi");
+    return;
+  }
+  size_t pos = 6;
+  while (pos < argv.size()) {
+    if (!strcasecmp(argv[pos].c_str(), "withdist")) {
+      range_.withdist = true;
+      range_.option_num++;
+    } else if (!strcasecmp(argv[pos].c_str(), "withhash")) {
+      range_.withhash = true;	
+      range_.option_num++;
+    } else if (!strcasecmp(argv[pos].c_str(), "withcoord")) {
+      range_.withcoord = true;	
+      range_.option_num++;
+    } else if (!strcasecmp(argv[pos].c_str(), "count")) {
+      range_.count = true; 
+      if (argv.size() < (pos+2)) {
+        res_.SetRes(CmdRes::kSyntaxErr);
+        return;        
+      }
+      std::string str_count = argv[++pos];
+      for (auto s : str_count) {
+        if (!isdigit(s)) {
+          res_.SetRes(CmdRes::kErrOther, "value is not an integer or out of range");
+          return;
+        }
+      } 
+      range_.count_limit = std::stoi(str_count);
+    } else if (!strcasecmp(argv[pos].c_str(), "store")) {
+      range_.store = true;
+      if (argv.size() < (pos+2)) {
+        res_.SetRes(CmdRes::kSyntaxErr);
+        return;        
+      }
+      range_.storekey = argv[++pos];
+    } else if (!strcasecmp(argv[pos].c_str(), "storedist")) {
+      range_.storedist = true;
+      if (argv.size() < (pos+2)) {
+        res_.SetRes(CmdRes::kSyntaxErr);
+        return;        
+      }
+      range_.storekey = argv[++pos];
+    } else if (!strcasecmp(argv[pos].c_str(), "asc")) {
+      range_.sort = Asc;	
+    } else if (!strcasecmp(argv[pos].c_str(), "desc")) {
+      range_.sort = Desc;	
+    } else {
+      res_.SetRes(CmdRes::kSyntaxErr);
+      return;
+    }
+    pos++;
+  }
+  if (range_.store && (range_.withdist || range_.withcoord || range_.withhash)) {
+    res_.SetRes(CmdRes::kErrOther, "STORE option in GEORADIUS is not compatible with WITHDIST, WITHHASH and WITHCOORDS options");
+    return;
+  }
+}
+
+void GeoRadiusCmd::Do() {
+  GetAllNeighbors(key_, range_, this->res_);
+}
+
+void GeoRadiusByMemberCmd::DoInitial(PikaCmdArgsType &argv, const CmdInfo* const ptr_info) {
+  if (!ptr_info->CheckArg(argv.size())) {
+    res_.SetRes(CmdRes::kWrongNum, kCmdNameGeoRadius);
+    return;
+  }
+  key_ = argv[1];
+  range_.member = argv[2];
+  slash::string2d(argv[3].data(), argv[3].size(), &range_.distance);
+  range_.unit = argv[4];
+  if (!check_unit(range_.unit)) {
+    res_.SetRes(CmdRes::kErrOther, "unsupported unit provided. please use m, km, ft, mi");
+    return;
+  }
+  size_t pos = 5;
+  while (pos < argv.size()) {
+    if (!strcasecmp(argv[pos].c_str(), "withdist")) {
+      range_.withdist = true;
+      range_.option_num++;
+    } else if (!strcasecmp(argv[pos].c_str(), "withhash")) {
+      range_.withhash = true; 
+      range_.option_num++;
+    } else if (!strcasecmp(argv[pos].c_str(), "withcoord")) {
+      range_.withcoord = true;  
+      range_.option_num++;
+    } else if (!strcasecmp(argv[pos].c_str(), "count")) {
+      range_.count = true; 
+      if (argv.size() < (pos+2)) {
+        res_.SetRes(CmdRes::kSyntaxErr);
+        return;        
+      }
+      std::string str_count = argv[++pos];
+      for (auto s : str_count) {
+        if (!isdigit(s)) {
+          res_.SetRes(CmdRes::kErrOther, "value is not an integer or out of range");
+          return;
+        }
+      } 
+      range_.count_limit = std::stoi(str_count);
+    } else if (!strcasecmp(argv[pos].c_str(), "store")) {
+      range_.store = true;
+      if (argv.size() < (pos+2)) {
+        res_.SetRes(CmdRes::kSyntaxErr);
+        return;        
+      }
+      range_.storekey = argv[++pos];
+    } else if (!strcasecmp(argv[pos].c_str(), "storedist")) {
+      range_.storedist = true;
+      if (argv.size() < (pos+2)) {
+        res_.SetRes(CmdRes::kSyntaxErr);
+        return;        
+      }
+      range_.storekey = argv[++pos];
+    } else if (!strcasecmp(argv[pos].c_str(), "asc")) {
+      range_.sort = Asc;  
+    } else if (!strcasecmp(argv[pos].c_str(), "desc")) {
+      range_.sort = Desc; 
+    } else {
+      res_.SetRes(CmdRes::kSyntaxErr);
+      return;
+    }
+    pos++;
+  }
+  if (range_.store && (range_.withdist || range_.withcoord || range_.withhash)) {
+    res_.SetRes(CmdRes::kErrOther, "STORE option in GEORADIUS is not compatible with WITHDIST, WITHHASH and WITHCOORDS options");
+    return;
+  }
+}
+
+void GeoRadiusByMemberCmd::Do() {
+  nemo::Status s;
+  double score;
+  s = g_pika_server->db()->ZScore(key_, range_.member, &score);
+  if (s.ok()) {
+    double xy[2];
+    GeoHashBits hash = { .bits = (uint64_t)score, .step = GEO_STEP_MAX };
+    geohashDecodeToLongLatWGS84(hash, xy);
+    range_.longitude = xy[0];
+    range_.latitude = xy[1];
+  }
+  GetAllNeighbors(key_, range_, this->res_);
+}

--- a/src/pika_geohash.cc
+++ b/src/pika_geohash.cc
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2013-2014, yinqiwen <yinqiwen@gmail.com>
+ * Copyright (c) 2014, Matt Stancliff <matt@genges.com>.
+ * Copyright (c) 2015-2016, Salvatore Sanfilippo <antirez@gmail.com>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of Redis nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "include/pika_geohash.h"
+
+/**
+ * Hashing works like this:
+ * Divide the world into 4 buckets.  Label each one as such:
+ *  -----------------
+ *  |       |       |
+ *  |       |       |
+ *  | 0,1   | 1,1   |
+ *  -----------------
+ *  |       |       |
+ *  |       |       |
+ *  | 0,0   | 1,0   |
+ *  -----------------
+ */
+
+/* Interleave lower bits of x and y, so the bits of x
+ * are in the even positions and bits from y in the odd;
+ * x and y must initially be less than 2**32 (65536).
+ * From:  https://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN
+ */
+static inline uint64_t interleave64(uint32_t xlo, uint32_t ylo) {
+    static const uint64_t B[] = {0x5555555555555555ULL, 0x3333333333333333ULL,
+                                 0x0F0F0F0F0F0F0F0FULL, 0x00FF00FF00FF00FFULL,
+                                 0x0000FFFF0000FFFFULL};
+    static const unsigned int S[] = {1, 2, 4, 8, 16};
+
+    uint64_t x = xlo;
+    uint64_t y = ylo;
+
+    x = (x | (x << S[4])) & B[4];
+    y = (y | (y << S[4])) & B[4];
+
+    x = (x | (x << S[3])) & B[3];
+    y = (y | (y << S[3])) & B[3];
+
+    x = (x | (x << S[2])) & B[2];
+    y = (y | (y << S[2])) & B[2];
+
+    x = (x | (x << S[1])) & B[1];
+    y = (y | (y << S[1])) & B[1];
+
+    x = (x | (x << S[0])) & B[0];
+    y = (y | (y << S[0])) & B[0];
+
+    return x | (y << 1);
+}
+
+/* reverse the interleave process
+ * derived from http://stackoverflow.com/questions/4909263
+ */
+static inline uint64_t deinterleave64(uint64_t interleaved) {
+    static const uint64_t B[] = {0x5555555555555555ULL, 0x3333333333333333ULL,
+                                 0x0F0F0F0F0F0F0F0FULL, 0x00FF00FF00FF00FFULL,
+                                 0x0000FFFF0000FFFFULL, 0x00000000FFFFFFFFULL};
+    static const unsigned int S[] = {0, 1, 2, 4, 8, 16};
+
+    uint64_t x = interleaved;
+    uint64_t y = interleaved >> 1;
+
+    x = (x | (x >> S[0])) & B[0];
+    y = (y | (y >> S[0])) & B[0];
+
+    x = (x | (x >> S[1])) & B[1];
+    y = (y | (y >> S[1])) & B[1];
+
+    x = (x | (x >> S[2])) & B[2];
+    y = (y | (y >> S[2])) & B[2];
+
+    x = (x | (x >> S[3])) & B[3];
+    y = (y | (y >> S[3])) & B[3];
+
+    x = (x | (x >> S[4])) & B[4];
+    y = (y | (y >> S[4])) & B[4];
+
+    x = (x | (x >> S[5])) & B[5];
+    y = (y | (y >> S[5])) & B[5];
+
+    return x | (y << 32);
+}
+
+void geohashGetCoordRange(GeoHashRange *long_range, GeoHashRange *lat_range) {
+    /* These are constraints from EPSG:900913 / EPSG:3785 / OSGEO:41001 */
+    /* We can't geocode at the north/south pole. */
+    long_range->max = GEO_LONG_MAX;
+    long_range->min = GEO_LONG_MIN;
+    lat_range->max = GEO_LAT_MAX;
+    lat_range->min = GEO_LAT_MIN;
+}
+
+int geohashEncode(const GeoHashRange *long_range, const GeoHashRange *lat_range,
+                  double longitude, double latitude, uint8_t step,
+                  GeoHashBits *hash) {
+    /* Check basic arguments sanity. */
+    if (hash == NULL || step > 32 || step == 0 ||
+        RANGEPISZERO(lat_range) || RANGEPISZERO(long_range)) return 0;
+
+    /* Return an error when trying to index outside the supported
+     * constraints. */
+    if (longitude > 180 || longitude < -180 ||
+        latitude > 85.05112878 || latitude < -85.05112878) return 0;
+
+    hash->bits = 0;
+    hash->step = step;
+
+    if (latitude < lat_range->min || latitude > lat_range->max ||
+        longitude < long_range->min || longitude > long_range->max) {
+        return 0;
+    }
+
+    double lat_offset =
+        (latitude - lat_range->min) / (lat_range->max - lat_range->min);
+    double long_offset =
+        (longitude - long_range->min) / (long_range->max - long_range->min);
+
+    /* convert to fixed point based on the step size */
+    lat_offset *= (1 << step);
+    long_offset *= (1 << step);
+    hash->bits = interleave64(lat_offset, long_offset);
+    return 1;
+}
+
+int geohashEncodeType(double longitude, double latitude, uint8_t step, GeoHashBits *hash) {
+    GeoHashRange r[2] = {GeoHashRange()};
+    geohashGetCoordRange(&r[0], &r[1]);
+    return geohashEncode(&r[0], &r[1], longitude, latitude, step, hash);
+}
+
+int geohashEncodeWGS84(double longitude, double latitude, uint8_t step,
+                       GeoHashBits *hash) {
+    return geohashEncodeType(longitude, latitude, step, hash);
+}
+
+int geohashDecode(const GeoHashRange long_range, const GeoHashRange lat_range,
+                   const GeoHashBits hash, GeoHashArea *area) {
+    if (HASHISZERO(hash) || NULL == area || RANGEISZERO(lat_range) ||
+        RANGEISZERO(long_range)) {
+        return 0;
+    }
+
+    area->hash = hash;
+    uint8_t step = hash.step;
+    uint64_t hash_sep = deinterleave64(hash.bits); /* hash = [LAT][LONG] */
+
+    double lat_scale = lat_range.max - lat_range.min;
+    double long_scale = long_range.max - long_range.min;
+
+    uint32_t ilato = hash_sep;       /* get lat part of deinterleaved hash */
+    uint32_t ilono = hash_sep >> 32; /* shift over to get long part of hash */
+
+    /* divide by 2**step.
+     * Then, for 0-1 coordinate, multiply times scale and add
+       to the min to get the absolute coordinate. */
+    area->latitude.min =
+        lat_range.min + (ilato * 1.0 / (1ull << step)) * lat_scale;
+    area->latitude.max =
+        lat_range.min + ((ilato + 1) * 1.0 / (1ull << step)) * lat_scale;
+    area->longitude.min =
+        long_range.min + (ilono * 1.0 / (1ull << step)) * long_scale;
+    area->longitude.max =
+        long_range.min + ((ilono + 1) * 1.0 / (1ull << step)) * long_scale;
+
+    return 1;
+}
+
+int geohashDecodeType(const GeoHashBits hash, GeoHashArea *area) {
+    GeoHashRange r[2] = {GeoHashRange()};
+    geohashGetCoordRange(&r[0], &r[1]);
+    return geohashDecode(r[0], r[1], hash, area);
+}
+
+int geohashDecodeWGS84(const GeoHashBits hash, GeoHashArea *area) {
+    return geohashDecodeType(hash, area);
+}
+
+int geohashDecodeAreaToLongLat(const GeoHashArea *area, double *xy) {
+    if (!xy) return 0;
+    xy[0] = (area->longitude.min + area->longitude.max) / 2;
+    xy[1] = (area->latitude.min + area->latitude.max) / 2;
+    return 1;
+}
+
+int geohashDecodeToLongLatType(const GeoHashBits hash, double *xy) {
+    GeoHashArea area = GeoHashArea();
+    if (!xy || !geohashDecodeType(hash, &area))
+        return 0;
+    return geohashDecodeAreaToLongLat(&area, xy);
+}
+
+int geohashDecodeToLongLatWGS84(const GeoHashBits hash, double *xy) {
+    return geohashDecodeToLongLatType(hash, xy);
+}
+
+static void geohash_move_x(GeoHashBits *hash, int8_t d) {
+    if (d == 0)
+        return;
+
+    uint64_t x = hash->bits & 0xaaaaaaaaaaaaaaaaULL;
+    uint64_t y = hash->bits & 0x5555555555555555ULL;
+
+    uint64_t zz = 0x5555555555555555ULL >> (64 - hash->step * 2);
+
+    if (d > 0) {
+        x = x + (zz + 1);
+    } else {
+        x = x | zz;
+        x = x - (zz + 1);
+    }
+
+    x &= (0xaaaaaaaaaaaaaaaaULL >> (64 - hash->step * 2));
+    hash->bits = (x | y);
+}
+
+static void geohash_move_y(GeoHashBits *hash, int8_t d) {
+    if (d == 0)
+        return;
+
+    uint64_t x = hash->bits & 0xaaaaaaaaaaaaaaaaULL;
+    uint64_t y = hash->bits & 0x5555555555555555ULL;
+
+    uint64_t zz = 0xaaaaaaaaaaaaaaaaULL >> (64 - hash->step * 2);
+    if (d > 0) {
+        y = y + (zz + 1);
+    } else {
+        y = y | zz;
+        y = y - (zz + 1);
+    }
+    y &= (0x5555555555555555ULL >> (64 - hash->step * 2));
+    hash->bits = (x | y);
+}
+
+void geohashNeighbors(const GeoHashBits *hash, GeoHashNeighbors *neighbors) {
+    neighbors->east = *hash;
+    neighbors->west = *hash;
+    neighbors->north = *hash;
+    neighbors->south = *hash;
+    neighbors->south_east = *hash;
+    neighbors->south_west = *hash;
+    neighbors->north_east = *hash;
+    neighbors->north_west = *hash;
+
+    geohash_move_x(&neighbors->east, 1);
+    geohash_move_y(&neighbors->east, 0);
+
+    geohash_move_x(&neighbors->west, -1);
+    geohash_move_y(&neighbors->west, 0);
+
+    geohash_move_x(&neighbors->south, 0);
+    geohash_move_y(&neighbors->south, -1);
+
+    geohash_move_x(&neighbors->north, 0);
+    geohash_move_y(&neighbors->north, 1);
+
+    geohash_move_x(&neighbors->north_west, -1);
+    geohash_move_y(&neighbors->north_west, 1);
+
+    geohash_move_x(&neighbors->north_east, 1);
+    geohash_move_y(&neighbors->north_east, 1);
+
+    geohash_move_x(&neighbors->south_east, 1);
+    geohash_move_y(&neighbors->south_east, -1);
+
+    geohash_move_x(&neighbors->south_west, -1);
+    geohash_move_y(&neighbors->south_west, -1);
+}

--- a/src/pika_geohash.cc
+++ b/src/pika_geohash.cc
@@ -144,14 +144,14 @@ int geohashEncode(const GeoHashRange *long_range, const GeoHashRange *lat_range,
         (longitude - long_range->min) / (long_range->max - long_range->min);
 
     /* convert to fixed point based on the step size */
-    lat_offset *= (1 << step);
-    long_offset *= (1 << step);
+    lat_offset *= (1ULL << step);
+    long_offset *= (1ULL << step);
     hash->bits = interleave64(lat_offset, long_offset);
     return 1;
 }
 
 int geohashEncodeType(double longitude, double latitude, uint8_t step, GeoHashBits *hash) {
-    GeoHashRange r[2] = {GeoHashRange()};
+    GeoHashRange r[2] = {{0}};
     geohashGetCoordRange(&r[0], &r[1]);
     return geohashEncode(&r[0], &r[1], longitude, latitude, step, hash);
 }
@@ -194,7 +194,7 @@ int geohashDecode(const GeoHashRange long_range, const GeoHashRange lat_range,
 }
 
 int geohashDecodeType(const GeoHashBits hash, GeoHashArea *area) {
-    GeoHashRange r[2] = {GeoHashRange()};
+    GeoHashRange r[2] = {{0}};
     geohashGetCoordRange(&r[0], &r[1]);
     return geohashDecode(r[0], r[1], hash, area);
 }
@@ -211,7 +211,7 @@ int geohashDecodeAreaToLongLat(const GeoHashArea *area, double *xy) {
 }
 
 int geohashDecodeToLongLatType(const GeoHashBits hash, double *xy) {
-    GeoHashArea area = GeoHashArea();
+    GeoHashArea area = {{0}};
     if (!xy || !geohashDecodeType(hash, &area))
         return 0;
     return geohashDecodeAreaToLongLat(&area, xy);

--- a/src/pika_geohash_helper.cc
+++ b/src/pika_geohash_helper.cc
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2013-2014, yinqiwen <yinqiwen@gmail.com>
+ * Copyright (c) 2014, Matt Stancliff <matt@genges.com>.
+ * Copyright (c) 2015-2016, Salvatore Sanfilippo <antirez@gmail.com>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of Redis nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* This is a C++ to C conversion from the ardb project.
+ * This file started out as:
+ * https://github.com/yinqiwen/ardb/blob/d42503/src/geo/geohash_helper.cpp
+ */
+
+//#include "fmacros.h"
+#include "include/pika_geohash_helper.h"
+//#include "debugmacro.h"
+#include <math.h>
+
+#define D_R (M_PI / 180.0)
+#define R_MAJOR 6378137.0
+#define R_MINOR 6356752.3142
+#define RATIO (R_MINOR / R_MAJOR)
+#define ECCENT (sqrt(1.0 - (RATIO *RATIO)))
+#define COM (0.5 * ECCENT)
+
+/// @brief The usual PI/180 constant
+const double DEG_TO_RAD = 0.017453292519943295769236907684886;
+/// @brief Earth's quatratic mean radius for WGS-84
+const double EARTH_RADIUS_IN_METERS = 6372797.560856;
+
+const double MERCATOR_MAX = 20037726.37;
+const double MERCATOR_MIN = -20037726.37;
+
+static inline double deg_rad(double ang) { return ang * D_R; }
+static inline double rad_deg(double ang) { return ang / D_R; }
+
+/* This function is used in order to estimate the step (bits precision)
+ * of the 9 search area boxes during radius queries. */
+uint8_t geohashEstimateStepsByRadius(double range_meters, double lat) {
+    if (range_meters == 0) return 18;
+    int step = 1;
+    while (range_meters < MERCATOR_MAX) {
+        range_meters *= 2;
+        step++;
+    }
+    step -= 2; /* Make sure range is included in most of the base cases. */
+
+    /* Wider range torwards the poles... Note: it is possible to do better
+     * than this approximation by computing the distance between meridians
+     * at this latitude, but this does the trick for now. */
+    if (lat > 66 || lat < -66) {
+        step--;
+        if (lat > 80 || lat < -80) step--;
+    }
+
+    /* Frame to valid range. */
+    if (step < 1) step = 1;
+    if (step > 18) step = 18;
+    return step;
+}
+
+/* Return the bounding box of the search area centered at latitude,longitude
+ * having a radius of radius_meter. bounds[0] - bounds[2] is the minimum
+ * and maxium longitude, while bounds[1] - bounds[3] is the minimum and
+ * maximum latitude. */
+int geohashBoundingBox(double longitude, double latitude, double radius_meters,
+                       double *bounds) {
+    if (!bounds) return 0;
+
+    bounds[0] = longitude - rad_deg(radius_meters/EARTH_RADIUS_IN_METERS/cos(deg_rad(latitude)));
+    bounds[2] = longitude + rad_deg(radius_meters/EARTH_RADIUS_IN_METERS/cos(deg_rad(latitude)));
+    bounds[1] = latitude - rad_deg(radius_meters/EARTH_RADIUS_IN_METERS);
+    bounds[3] = latitude + rad_deg(radius_meters/EARTH_RADIUS_IN_METERS);
+    return 1;
+}
+
+/* Return a set of areas (center + 8) that are able to cover a range query
+ * for the specified position and radius. */
+GeoHashRadius geohashGetAreasByRadius(double longitude, double latitude, double radius_meters) {
+    GeoHashRange long_range, lat_range;
+    GeoHashRadius radius;
+    GeoHashBits hash;
+    GeoHashNeighbors neighbors;
+    GeoHashArea area;
+    double min_lon, max_lon, min_lat, max_lat;
+    double bounds[4];
+    int steps;
+
+    geohashBoundingBox(longitude, latitude, radius_meters, bounds);
+    min_lon = bounds[0];
+    min_lat = bounds[1];
+    max_lon = bounds[2];
+    max_lat = bounds[3];
+
+    steps = geohashEstimateStepsByRadius(radius_meters,latitude);
+
+    geohashGetCoordRange(&long_range,&lat_range);
+    geohashEncode(&long_range,&lat_range,longitude,latitude,steps,&hash);
+    geohashNeighbors(&hash,&neighbors);
+    geohashDecode(long_range,lat_range,hash,&area);
+
+    /* Check if the step is enough at the limits of the covered area.
+     * Sometimes when the search area is near an edge of the
+     * area, the estimated step is not small enough, since one of the
+     * north / south / west / east square is too near to the search area
+     * to cover everything. */
+    int decrease_step = 0;
+    {
+        GeoHashArea north, south, east, west;
+
+        geohashDecode(long_range, lat_range, neighbors.north, &north);
+        geohashDecode(long_range, lat_range, neighbors.south, &south);
+        geohashDecode(long_range, lat_range, neighbors.east, &east);
+        geohashDecode(long_range, lat_range, neighbors.west, &west);
+
+        if (geohashGetDistance(longitude,latitude,longitude,north.latitude.max)
+            < radius_meters) decrease_step = 1;
+        if (geohashGetDistance(longitude,latitude,longitude,south.latitude.min)
+            < radius_meters) decrease_step = 1;
+        if (geohashGetDistance(longitude,latitude,east.longitude.max,latitude)
+            < radius_meters) decrease_step = 1;
+        if (geohashGetDistance(longitude,latitude,west.longitude.min,latitude)
+            < radius_meters) decrease_step = 1;
+    }
+
+    if (steps > 1 && decrease_step) {
+        steps--;
+        geohashEncode(&long_range,&lat_range,longitude,latitude,steps,&hash);
+        geohashNeighbors(&hash,&neighbors);
+        geohashDecode(long_range,lat_range,hash,&area);
+    }
+
+    /* Exclude the search areas that are useless. */
+    if (area.latitude.min < min_lat) {
+        GZERO(neighbors.south);
+        GZERO(neighbors.south_west);
+        GZERO(neighbors.south_east);
+    }
+    if (area.latitude.max > max_lat) {
+        GZERO(neighbors.north);
+        GZERO(neighbors.north_east);
+        GZERO(neighbors.north_west);
+    }
+    if (area.longitude.min < min_lon) {
+        GZERO(neighbors.west);
+        GZERO(neighbors.south_west);
+        GZERO(neighbors.north_west);
+    }
+    if (area.longitude.max > max_lon) {
+        GZERO(neighbors.east);
+        GZERO(neighbors.south_east);
+        GZERO(neighbors.north_east);
+    }
+    radius.hash = hash;
+    radius.neighbors = neighbors;
+    radius.area = area;
+    return radius;
+}
+
+GeoHashRadius geohashGetAreasByRadiusWGS84(double longitude, double latitude,
+                                           double radius_meters) {
+    return geohashGetAreasByRadius(longitude, latitude, radius_meters);
+}
+
+GeoHashFix52Bits geohashAlign52Bits(const GeoHashBits hash) {
+    uint64_t bits = hash.bits;
+    bits <<= (36 - hash.step * 2);
+    return bits;
+}
+
+/* Calculate distance using haversin great circle distance formula. */
+double geohashGetDistance(double lon1d, double lat1d, double lon2d, double lat2d) {
+    double lat1r, lon1r, lat2r, lon2r, u, v;
+    lat1r = deg_rad(lat1d);
+    lon1r = deg_rad(lon1d);
+    lat2r = deg_rad(lat2d);
+    lon2r = deg_rad(lon2d);
+    u = sin((lat2r - lat1r) / 2);
+    v = sin((lon2r - lon1r) / 2);
+    return 2.0 * EARTH_RADIUS_IN_METERS *
+           asin(sqrt(u * u + cos(lat1r) * cos(lat2r) * v * v));
+}
+
+int geohashGetDistanceIfInRadius(double x1, double y1,
+                                 double x2, double y2, double radius,
+                                 double *distance) {
+    *distance = geohashGetDistance(x1, y1, x2, y2);
+    if (*distance > radius) return 0;
+    return 1;
+}
+
+int geohashGetDistanceIfInRadiusWGS84(double x1, double y1, double x2,
+                                      double y2, double radius,
+                                      double *distance) {
+    return geohashGetDistanceIfInRadius(x1, y1, x2, y2, radius, distance);
+}


### PR DESCRIPTION
as title, due to blackwidow stores the score of zset as double, the precision lost no longer exists.