### PR TITLE
last_record_offset should be assigned to zero when binlog sender roll…

### DIFF
--- a/src/pika_binlog_sender_thread.cc
+++ b/src/pika_binlog_sender_thread.cc
@@ -222,7 +222,7 @@ Status PikaBinlogSenderThread::Parse(std::string &scratch) {
 
         filenum_++;
         con_offset_ = 0;
-        last_record_offset_ = con_offset_ % kBlockSize;
+        last_record_offset_ = 0;
       } else {
         usleep(10000);
       }


### PR DESCRIPTION
… to next File