### PR TITLE
allow master-slave connection to be established with any reachable IP without binding NIC

### DIFF
--- a/include/pika_trysync_thread.h
+++ b/include/pika_trysync_thread.h
@@ -23,7 +23,7 @@ class PikaTrysyncThread : public pink::Thread {
   int64_t sid_;
   pink::PinkCli *cli_;
 
-  bool Send();
+  bool Send(std::string lip);
   bool RecvProc();
   void PrepareRsync();
   bool TryUpdateMasterOffset();

--- a/src/pika_binlog_sender_thread.cc
+++ b/src/pika_binlog_sender_thread.cc
@@ -247,7 +247,7 @@ void* PikaBinlogSenderThread::ThreadMain() {
   while (!should_stop()) {
     sleep(2);
     // 1. Connect to slave
-    result = cli_->Connect(ip_, port_, g_pika_server->host());
+    result = cli_->Connect(ip_, port_, "");
     LOG(INFO) << "BinlogSender Connect slave(" << ip_ << ":" << port_ << ") " << result.ToString();
 
     // 2. Auth

--- a/src/pika_slaveping_thread.cc
+++ b/src/pika_slaveping_thread.cc
@@ -53,7 +53,7 @@ void* PikaSlavepingThread::ThreadMain() {
   while (!should_stop() && g_pika_server->ShouldStartPingMaster()) {
     if (!should_stop() && (cli_->Connect(g_pika_server->master_ip(),
                                          g_pika_server->master_port() + 2000,
-                                         g_pika_server->host())).ok()) {
+                                         "")).ok()) {
       cli_->set_send_timeout(1000);
       cli_->set_recv_timeout(1000);
       connect_retry_times = 0;

--- a/src/pika_trysync_thread.cc
+++ b/src/pika_trysync_thread.cc
@@ -6,6 +6,9 @@
 #include <fstream>
 #include <glog/logging.h>
 #include <poll.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 
 #include "slash/include/env.h"
 #include "slash/include/rsync.h"
@@ -25,7 +28,7 @@ PikaTrysyncThread::~PikaTrysyncThread() {
   LOG(INFO) << " Trysync thread " << thread_id() << " exit!!!";
 }
 
-bool PikaTrysyncThread::Send() {
+bool PikaTrysyncThread::Send(std::string lip) {
   pink::RedisCmdArgsType argv;
   std::string wbuf_str;
   std::string masterauth = g_pika_conf->masterauth();
@@ -38,7 +41,7 @@ bool PikaTrysyncThread::Send() {
   argv.clear();
   std::string tbuf_str;
   argv.push_back("trysync");
-  argv.push_back(g_pika_server->host());
+  argv.push_back(lip);
   argv.push_back(std::to_string(g_pika_server->port()));
   uint32_t filenum;
   uint64_t pro_offset;
@@ -239,20 +242,42 @@ void* PikaTrysyncThread::ThreadMain() {
 
     // Start rsync service
     PrepareRsync();
-    std::string ip_port = slash::IpPortString(master_ip, master_port);
-    // We append the master ip port after module name
-    // To make sure only data from current master is received
-    int ret = slash::StartRsync(dbsync_path, kDBSyncModule + "_" + ip_port, g_pika_server->host(), g_pika_conf->port() + 3000);
-    if (0 != ret) {
-      LOG(WARNING) << "Failed to start rsync, path:" << dbsync_path << " error : " << ret;
-    }
-    LOG(INFO) << "Finish to start rsync, path:" << dbsync_path;
 
-    if ((cli_->Connect(master_ip, master_port, g_pika_server->host())).ok()) {
+    if ((cli_->Connect(master_ip, master_port, "")).ok()) {
       LOG(INFO) << "Connect to master ip:" << master_ip << "port: " << master_port;
       cli_->set_send_timeout(30000);
       cli_->set_recv_timeout(30000);
-      if (Send() && RecvProc()) {
+      std::string ip_port = slash::IpPortString(master_ip, master_port);
+      struct sockaddr_in laddr;
+      socklen_t llen = sizeof(laddr);
+      getsockname(cli_->fd(), (struct sockaddr*) &laddr, &llen);
+      std::string lip(inet_ntoa(laddr.sin_addr));
+      // We append the master ip port after module name
+      // To make sure only data from current master is received
+      int ret = slash::StartRsync(dbsync_path, kDBSyncModule + "_" + ip_port, lip, g_pika_conf->port() + 3000);
+      if (0 != ret) {
+        LOG(WARNING) << "Failed to start rsync, path:" << dbsync_path << " error : " << ret;
+      }
+      LOG(INFO) << "Finish to start rsync, path:" << dbsync_path;
+
+      // Make sure the listening addr of rsyncd is accessible, avoid the corner case
+      // that rsync --daemon process is started but not finished listening on the socket
+      pink::PinkCli *rsync = pink::NewRedisCli();
+      int retry_times;
+      for (retry_times = 0; retry_times < 5; retry_times++) {
+        if (rsync->Connect(lip, g_pika_conf->port() + 3000, "").ok()) {
+          LOG(INFO) << "rsync successfully started, address:" << lip << ":" << g_pika_conf->port() + 3000;
+          rsync->Close();
+          break;
+        } else {
+          sleep(1);
+        }
+      }
+      if (retry_times >= 5) {
+        LOG(WARNING) << "connecting to rsync failed, address:" << lip << ":" << g_pika_conf->port() + 3000;
+      }
+
+      if (Send(lip) && RecvProc()) {
         g_pika_server->ConnectMasterDone();
         // Stop rsync, binlog sync with master is begin
         slash::StopRsync(dbsync_path);


### PR DESCRIPTION
1. slaveping, trysync... etc. invokes pink::PinkCli->Connect() with the third argument leaving blank, which means NOT to bind a specific local address, but let the OS choose automatically.
2. trysync send the local ip of slave to master and use the localip to start rsyncd and name the module
3. because of rsync --daemon process is started BEFORE the daemon actually listen() on the socket, wait at most 5 seconds to ensure.
4. after receiving trysync, the master connect to the slave's rsyncd to get its localip and use as module name.
5. when master's localip isn't the same as host_(which is the first IP on the NIC holding the default route), temporarily write a different info file with modified localip to let the slave pass the sanity check.

tested in our test environment, need review and thoroughly testing, thanks~