### PR TITLE
when block-cache is not set, restore to default behavior that each ro…

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -105,8 +105,8 @@ max-cache-files : 5000
 max-bytes-for-level-multiplier : 10
 # BlockBasedTable block_size, default 4k
 # block-size: 4096
-# block LRU cache, default 8M
-# block-cache: 8388608
+# block LRU cache, default 8M each RocksDB, positive value will create a SHARED block cache
+# block-cache: 0
 # whether or not index and filter blocks is stored in block cache
 # cache-index-and-filter-blocks: no
 # when set to yes, bloomfilter of the last level will not be built

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -209,10 +209,10 @@ int PikaConf::Load()
     block_size_ = 4 * 1024;
   }
 
-  block_cache_ = 8 * 1024 * 1024;
+  block_cache_ = 0;
   GetConfInt("block-cache", &block_cache_);
-  if (block_cache_ <= 0) {
-    block_cache_ = 8 * 1024 * 1024;
+  if (block_cache_ < 0) {
+    block_cache_ = 0;
   }
 
   std::string ciafb;

--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -241,7 +241,9 @@ bool PikaServer::ServerInit() {
 
 void PikaServer::RocksdbTableOptionInit(rocksdb::BlockBasedTableOptions* table_option) {
   table_option->block_size = g_pika_conf->block_size();
-  table_option->block_cache = rocksdb::NewLRUCache(g_pika_conf->block_cache());
+  if (g_pika_conf->block_cache() > 0) {
+    table_option->block_cache = rocksdb::NewLRUCache(g_pika_conf->block_cache());
+  }
   table_option->cache_index_and_filter_blocks = g_pika_conf->cache_index_and_filter_blocks();
 }
 


### PR DESCRIPTION
…cksdb has its own block_cache

---
老的block_cache 是每个 RocksDB 实例 8M
#358 里改成了传一个 rocksdb::NewLRUCache() 进 blackwidow 作为 option，副作用是这个变量会变成共享的（除非单独传一个大小进 bw，在 bw 里 New，感觉太 dirty...）
这样五个 DB 共享 8M，和原来行为不一致了。。。

这个 PR 在不指定 block-cache 的时候恢复原来的逻辑，可以酌情食用....

其实我觉得干脆一把改成共享的，调大点，32M什么的，是不是更靠谱？
@baotiao @KernelMaker @Axlgrep 

