### PR TITLE
enlarge default block_cache to 32M because previous one is not shared

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -105,8 +105,8 @@ max-cache-files : 5000
 max-bytes-for-level-multiplier : 10
 # BlockBasedTable block_size, default 4k
 # block-size: 4096
-# block LRU cache, default 8M
-# block-cache: 8388608
+# block LRU cache, default 32M
+# block-cache: 33554432
 # whether or not index and filter blocks is stored in block cache
 # cache-index-and-filter-blocks: no
 # when set to yes, bloomfilter of the last level will not be built

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -209,10 +209,10 @@ int PikaConf::Load()
     block_size_ = 4 * 1024;
   }
 
-  block_cache_ = 8 * 1024 * 1024;
+  block_cache_ = 32 * 1024 * 1024;
   GetConfInt("block-cache", &block_cache_);
   if (block_cache_ <= 0) {
-    block_cache_ = 8 * 1024 * 1024;
+    block_cache_ = 32 * 1024 * 1024;
   }
 
   std::string ciafb;


### PR DESCRIPTION
和 #359 选一个吃，不要都吃……