### PR TITLE
Support disconnect for double master

### DIFF
--- a/src/pika_admin.cc
+++ b/src/pika_admin.cc
@@ -89,7 +89,7 @@ void SlaveofCmd::Do() {
     }
 
     // Stop rsync
-    LOG(INFO) << "start slaveof, stop rsync first";
+    LOG(INFO) << "Start slaveof, stop rsync first";
     slash::StopRsync(g_pika_conf->db_sync_path());
     g_pika_server->RemoveMaster();
 
@@ -104,6 +104,22 @@ void SlaveofCmd::Do() {
         g_pika_server->PurgeLogs(filenum_ - 1, true, true);
       }
       g_pika_server->logger_->SetProducerStatus(filenum_, pro_offset_);
+    }
+  } else {
+    if (is_noone_) {
+      // Stop rsync
+      LOG(INFO) << "Slaveof no one in double-master mode";
+      slash::StopRsync(g_pika_conf->db_sync_path());
+
+      g_pika_server->RemoveMaster();
+
+      std::string double_master_ip = g_pika_conf->double_master_ip();
+      if (double_master_ip == "127.0.0.1") {
+        double_master_ip = g_pika_server->host();
+      }
+      g_pika_server->DeleteSlave(double_master_ip, g_pika_conf->double_master_port());
+      res_.SetRes(CmdRes::kOk);
+      return;
     }
   }
 

--- a/src/pika_trysync_thread.cc
+++ b/src/pika_trysync_thread.cc
@@ -244,7 +244,7 @@ void* PikaTrysyncThread::ThreadMain() {
     PrepareRsync();
 
     if ((cli_->Connect(master_ip, master_port, "")).ok()) {
-      LOG(INFO) << "Connect to master ip:" << master_ip << "port: " << master_port;
+      LOG(INFO) << "Connect to master ip:" << master_ip << " port: " << master_port;
       cli_->set_send_timeout(30000);
       cli_->set_recv_timeout(30000);
       std::string ip_port = slash::IpPortString(master_ip, master_port);


### PR DESCRIPTION
双主节点分别执行`slaveof no one`用来断开双主连接. @Axlgrep  @fancy-rabbit  please review this.