### PR TITLE
add warning log in AutoCompactRange(), when there is not enough disk …

### DIFF
--- a/src/pika_server.cc
+++ b/src/pika_server.cc
@@ -1274,6 +1274,9 @@ void PikaServer::AutoCompactRange() {
           LOG(INFO) << "[Interval]schedule compactRange Failed, freesize: " << free_size/1048576 << "MB, disksize: " << total_size/1048576
             << "MB, error: " << s.ToString();
         }
+      } else {
+        LOG(WARNING) << "compact-interval failed, because there is not enough disk space left, freesize"
+          << free_size/1048576 << "MB, disksize: " << total_size/1048576 << "MB";
       }
     }
     return;
@@ -1321,6 +1324,9 @@ void PikaServer::AutoCompactRange() {
             << "MB, error: " << s.ToString();
         }
         have_scheduled_crontask_ = true;
+      } else {
+        LOG(WARNING) << "compact-cron failed, because there is not enough disk space left, freesize"
+          << free_size/1048576 << "MB, disksize: " << total_size/1048576 << "MB";
       }
     }
   }


### PR DESCRIPTION
…space left to exec compact task