### PR TITLE
bugfix Pksetexat Cmd will hash into wrong slot in sharding mode

### DIFF
--- a/include/pika_kv.h
+++ b/include/pika_kv.h
@@ -669,6 +669,11 @@ class PKSetexAtCmd : public Cmd {
 public:
   PKSetexAtCmd(const std::string& name, int arity, uint16_t flag)
       : Cmd(name, arity, flag), time_stamp_(0) {}
+  virtual std::vector<std::string> current_key() const {
+    std::vector<std::string> res;
+    res.push_back(key_);
+    return res;
+  }
   virtual void Do(std::shared_ptr<Partition> partition = nullptr);
   virtual Cmd* Clone() override {
     return new PKSetexAtCmd(*this);


### PR DESCRIPTION
overload cmd Pksetexat current_key()