### PR TITLE
Bugfix Master Slave Sync connection break

### DIFF
--- a/include/pika_define.h
+++ b/include/pika_define.h
@@ -16,6 +16,7 @@
 #define PIKA_REPL_SERVER_TP_SIZE        3
 #define PIKA_META_SYNC_MAX_WAIT_TIME    10
 #define PIKA_SCAN_STEP_LENGTH           1000
+#define PIKA_PB_MAX_MESSAGE             (1 << 28) // 256MB
 
 class PikaServer;
 

--- a/include/pika_repl_client.h
+++ b/include/pika_repl_client.h
@@ -121,6 +121,7 @@ class PikaReplClient {
   int next_avail_;
   std::hash<std::string> str_hash;
   std::vector<PikaReplBgWorker*> bg_workers_;
+  pink::ThreadPool* pool_;
 };
 
 #endif

--- a/include/pika_repl_server.h
+++ b/include/pika_repl_server.h
@@ -30,6 +30,7 @@ class PikaReplServer {
   int Stop();
 
   slash::Status SendSlaveBinlogChips(const std::string& ip, int port, const std::vector<WriteTask>& tasks);
+  void BuildBinlogSyncResp(const std::vector<WriteTask>& tasks, InnerMessage::InnerResponse* resp);
   slash::Status Write(const std::string& ip, const int port, const std::string& msg);
 
   void Schedule(pink::TaskFunc func, void* arg);

--- a/include/pika_rm.h
+++ b/include/pika_rm.h
@@ -220,6 +220,7 @@ class BinlogReaderManager {
   ~BinlogReaderManager();
   Status FetchBinlogReader(const RmNode& rm_node, std::shared_ptr<PikaBinlogReader>* reader);
   Status ReleaseBinlogReader(const RmNode& rm_node);
+  std::string ToStringStatus();
  private:
   slash::Mutex reader_mu_;
   std::unordered_map<RmNode, std::shared_ptr<PikaBinlogReader>, hash_rm_node> occupied_;

--- a/src/pika_repl_server_conn.cc
+++ b/src/pika_repl_server_conn.cc
@@ -39,6 +39,8 @@ void PikaReplServerConn::HandleMetaSyncRequest(void* arg) {
     response.set_code(InnerMessage::kError);
     response.set_reply("Auth with master error, Invalid masterauth");
   } else {
+    LOG(INFO) << "Receive MetaSync, Slave ip: " << node.ip() << ", Slave port:"
+      << node.port();
     std::vector<TableStruct> table_structs = g_pika_conf->table_structs();
     bool success = g_pika_server->TryAddSlave(node.ip(), node.port(), conn->fd(), table_structs);
     const std::string ip_port = slash::IpPortString(node.ip(), node.port());
@@ -409,7 +411,6 @@ int PikaReplServerConn::DealMessage() {
     LOG(WARNING) << "Pika repl server connection pb parse error.";
     return -1;
   }
-  int res = 0;
   switch (req->type()) {
     case InnerMessage::kMetaSync:
     {
@@ -444,5 +445,5 @@ int PikaReplServerConn::DealMessage() {
     default:
       break;
   }
-  return res;
+  return 0;
 }


### PR DESCRIPTION
1.Due to protobuf's rejection of large command(over 64M) on the slave side,
connection is closed.

Improve pb allowed command size to be 256M.

2.Large command will consume a lot of time on slave side. That may lead
to ReplClient epoll Schedule block. Last ack response lead to master
timeout. Then, connection may rebuild on the slave side.

ReplBgWorker now write db in thread_pool.