### PR TITLE
Configuration Mod

### DIFF
--- a/conf/pika.conf
+++ b/conf/pika.conf
@@ -83,10 +83,8 @@ slave-priority : 100
 #                           if the freesize/disksize > 60%. NOTICE:compact-interval is prior than compact-cron;
 #compact-interval :
 
-# server-id for hub
-server-id : 1
-
-# consensus level defines how many confirms does leader get, before commit this log to client
+# consensus level defines how many confirms does leader get, before commit this log to client,
+#                 only [0, 1, 2] is valid
 consensus-level : 0
 
 # the size of flow control window while sync binlog between master and slave.Default is 9000 and the maximum is 90000.

--- a/src/pika_conf.cc
+++ b/src/pika_conf.cc
@@ -139,6 +139,12 @@ int PikaConf::Load()
 
   int tmp_consensus_level = 0;
   GetConfInt("consensus-level", &tmp_consensus_level);
+  if (tmp_consensus_level != 0 &&
+      tmp_consensus_level != 1 &&
+      tmp_consensus_level != 2) {
+    LOG(FATAL) << "consensus-level " << tmp_consensus_level <<
+      " is invalid, please pick one of [0, 1, 2]";
+  }
   consensus_level_.store(tmp_consensus_level);
 
   GetConfInt("slowlog-max-len", &slowlog_max_len_);


### PR DESCRIPTION
Remove conf server-id (no longer support)
Add limitation on conf consensus-level, only [0, 1, 2] is valid