### PR TITLE
Support unlink command

### DIFF
--- a/include/pika_command.h
+++ b/include/pika_command.h
@@ -51,6 +51,7 @@ const std::string kCmdDummy = "dummy";
 const std::string kCmdNameSet = "set";
 const std::string kCmdNameGet = "get";
 const std::string kCmdNameDel = "del";
+const std::string kCmdNameUnlink = "unlink";
 const std::string kCmdNameIncr = "incr";
 const std::string kCmdNameIncrby = "incrby";
 const std::string kCmdNameIncrbyfloat = "incrbyfloat";

--- a/src/pika_command.cc
+++ b/src/pika_command.cc
@@ -131,6 +131,9 @@ void InitCmdTable(std::unordered_map<std::string, Cmd*> *cmd_table) {
   ////DelCmd
   Cmd* delptr = new DelCmd(kCmdNameDel, -2, kCmdFlagsWrite | kCmdFlagsMultiPartition | kCmdFlagsKv);
   cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameDel, delptr));
+  ////UnlinkCmd
+  Cmd* unlinkptr = new DelCmd(kCmdNameUnlink, -2, kCmdFlagsWrite | kCmdFlagsMultiPartition | kCmdFlagsKv);
+  cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameUnlink, unlinkptr));
   ////IncrCmd
   Cmd* incrptr = new IncrCmd(kCmdNameIncr, 2, kCmdFlagsWrite | kCmdFlagsSinglePartition | kCmdFlagsKv);
   cmd_table->insert(std::pair<std::string, Cmd*>(kCmdNameIncr, incrptr));

--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -166,7 +166,7 @@ void GetCmd::Do(std::shared_ptr<Partition> partition) {
 
 void DelCmd::DoInitial() {
   if (!CheckArg(argv_.size())) {
-    res_.SetRes(CmdRes::kWrongNum, kCmdNameDel);
+    res_.SetRes(CmdRes::kWrongNum, name());
     return;
   }
   std::vector<std::string>::iterator iter = argv_.begin();
@@ -180,7 +180,7 @@ void DelCmd::Do(std::shared_ptr<Partition> partition) {
   if (count >= 0) {
     res_.AppendInteger(count);
   } else {
-    res_.SetRes(CmdRes::kErrOther, "delete error");
+    res_.SetRes(CmdRes::kErrOther, name() + " error");
   }
   return;
 }

--- a/tests/unit/basic.tcl
+++ b/tests/unit/basic.tcl
@@ -26,6 +26,40 @@ start_server {tags {"basic"}} {
         list [r del foo1 foo2 foo3 foo4] [r mget foo1 foo2 foo3]
     } {3 {{} {} {}}}
 
+    test {UNLINK against a single item} {
+        r set x foobar
+        r unlink x
+        r get x
+    } {}
+
+    test {Vararg UNLINK} {
+        r set foo1 bar1
+        r set foo2 bar2
+        r set foo3 bar3
+        list [r unlink foo1 foo2 foo3] [r mget foo1 foo2 foo3]
+    } {3 {{} {} {}}}
+
+    test {Return value of UNLINK} {
+        r set x foobar
+        assert_equal 1 [r unlink x]
+        assert_equal 0 [r unlink x]
+        r set foo1 bar1
+        r set foo2 bar2
+        assert_equal 2 [r unlink foo1 foo2]
+        assert_equal 0 [r unlink foo1]
+        assert_equal 0 [r unlink foo1 foo2]
+    }
+
+    test {Wrong arg number of DEL} {
+        catch {r del} err
+        format $err
+    } {ERR*del*}
+
+    test {Wrong arg number of UNLINK} {
+        catch {r unlink} err
+        format $err
+    } {ERR*unlink*}
+
     test {KEYS with pattern} {
         foreach key {key_x key_y key_z foo_a foo_b foo_c} {
             r set $key hello


### PR DESCRIPTION
Solve the issue #864, unlink command is just an alias for the del command, since del command is quick and lightweight even the deleted key is a big key.