### PR TITLE
Bugfix

### DIFF
--- a/src/pika_slot.cc
+++ b/src/pika_slot.cc
@@ -170,7 +170,8 @@ void SlotsMgrtTagSlotAsyncCmd::Do(std::shared_ptr<Partition> partition) {
   if (!master_partition) {
     LOG(WARNING) << "Sync Master Partition: " << g_pika_conf->default_table() << ":" << slot_num_
         << ", NotFound";
-    is_exist = false;
+    res_.SetRes(CmdRes::kNotFound, kCmdNameSlotsMgrtTagSlotAsync);
+    return;
   }
   is_exist = master_partition->CheckSlaveNodeExist(dest_ip_, dest_port_);
   if (is_exist) {


### PR DESCRIPTION
SlotsMgrtTagSlotAsyncCmd may lead to coredump if Sync Master Partition
is not found.