### PR TITLE
Bugfix

### DIFF
--- a/src/pika_cluster.cc
+++ b/src/pika_cluster.cc
@@ -489,19 +489,16 @@ void PkClusterSlotsSlaveofCmd::DoInitial() {
     }
   }
 
+  bool all_slots = false;
   if (!strcasecmp(argv_[4].data(), "all")) {
-    std::string table_name = g_pika_conf->default_table();
-    slots_ = g_pika_server->GetTablePartitionIds(table_name);
+    // not know which table yet
+    all_slots = true;
   } else {
     Status s = ParseSlotGroup(argv_[4], &slots_);
     if (!s.ok()) {
       res_.SetRes(CmdRes::kErrOther, s.ToString());
       return;
     }
-  }
-
-  if (slots_.empty()) {
-    res_.SetRes(CmdRes::kErrOther, "Slots set empty");
   }
 
   uint64_t table_id;
@@ -536,11 +533,19 @@ void PkClusterSlotsSlaveofCmd::DoInitial() {
       res_.SetRes(CmdRes::kErrOther, "syntax error");
       return;
   }
+
   if (!g_pika_server->IsTableExist(table_name_)) {
     res_.SetRes(CmdRes::kInvalidTable);
     return;
   }
 
+  if (all_slots) {
+    slots_ = g_pika_server->GetTablePartitionIds(table_name_);
+  }
+
+  if (slots_.empty()) {
+    res_.SetRes(CmdRes::kErrOther, "Slots set empty");
+  }
 }
 
 void PkClusterSlotsSlaveofCmd::Do(std::shared_ptr<Partition> partition) {


### PR DESCRIPTION
Command "pkcluster slotsslaveof ip port all table_id", "all" option
adapts to default table instead of "table_id" option.