### PR TITLE
Bugfix

### DIFF
--- a/src/pika_inner_message.proto
+++ b/src/pika_inner_message.proto
@@ -12,6 +12,7 @@ enum Type {
 enum StatusCode {
   kOk       = 1;
   kError    = 2;
+  kOther    = 3;
 }
 
 message BinlogOffset {

--- a/src/pika_repl_client_conn.cc
+++ b/src/pika_repl_client_conn.cc
@@ -95,6 +95,13 @@ void PikaReplClientConn::HandleMetaSyncResponse(void* arg) {
   std::shared_ptr<pink::PbConn> conn = task_arg->conn;
   std::shared_ptr<InnerMessage::InnerResponse> response = task_arg->res;
 
+  if (response->code() == InnerMessage::kOther) {
+    std::string reply = response->has_reply() ? response->reply() : "";
+    // keep sending MetaSync
+    LOG(WARNING) << "Meta Sync Failed: " << reply << " will keep sending MetaSync msg";
+    return;
+  }
+
   if (response->code() != InnerMessage::kOk) {
     std::string reply = response->has_reply() ? response->reply() : "";
     LOG(WARNING) << "Meta Sync Failed: " << reply;
@@ -279,6 +286,7 @@ Status PikaReplClientConn::TrySyncConsensusCheck(
     return s;
   }
   slave_partition->SetReplState(ReplState::kTryConnect);
+
   return s;
 }
 

--- a/src/pika_repl_server_conn.cc
+++ b/src/pika_repl_server_conn.cc
@@ -46,7 +46,7 @@ void PikaReplServerConn::HandleMetaSyncRequest(void* arg) {
     const std::string ip_port = slash::IpPortString(node.ip(), node.port());
     g_pika_rm->ReplServerUpdateClientConnMap(ip_port, conn->fd());
     if (!success) {
-      response.set_code(InnerMessage::kError);
+      response.set_code(InnerMessage::kOther);
       response.set_reply("Slave AlreadyExist");
     } else {
       g_pika_server->BecomeMaster();


### PR DESCRIPTION
Condition that slave master conn is broken, slave feel that broken and
send metasync msg again. Master feel that broken after receiving slave's
metasync msg. Instead of reject slave's metasync request, master should
notice slave keep trying send metasync because next time master may feel
that broken conn, remove old slave node and accept this new metasync msg.