### PR TITLE
Bugfix: add reconnection when binlog sync message lost

### DIFF
--- a/src/pika_repl_client_conn.cc
+++ b/src/pika_repl_client_conn.cc
@@ -252,6 +252,9 @@ void PikaReplClientConn::HandleTrySyncResponse(void* arg) {
     LogOffset offset(boffset, logic_last_offset);
     g_pika_rm->SendPartitionBinlogSyncAckRequest(table_name, partition_id, offset, offset, true);
     slave_partition->SetReplState(ReplState::kConnected);
+    // after connected, update receive time first to avoid connection timeout
+    slave_partition->SetLastRecvTime(slash::NowMicros());
+
     LOG(INFO)    << "Partition: " << partition_name << " TrySync Ok";
   } else if (try_sync_response.reply_code() == InnerMessage::InnerResponse::TrySync::kSyncPointBePurged) {
     slave_partition->SetReplState(ReplState::kTryDBSync);


### PR DESCRIPTION
When binlog sync or ack message lost in network, master can not receive corresponding ack message, this lead slave sent_offset is always larger than acked_offset. 
In function WakeUpSlaveBinlogSync, master check sent and ack offset to read binlog to the write queue, so new binlog will never sync to slave node.
Worse still, the heart beat by PikaAuxiliaryThread will always keep slave node alive, this dead slave node never sync binlog and cannot be remove by master automatically.
We add offset check in HandleBinlogSyncRequest, message lose will trigger slave node timeout, and will lead reconnect to fix this problem.