### PR TITLE
fix:can't sync binlog when exec redis cmd setnx

### DIFF
--- a/include/pika_consensus.h
+++ b/include/pika_consensus.h
@@ -208,10 +208,10 @@ class ConsensusCoordinator {
   Status InternalAppendLog(const BinlogItem& item,
       std::shared_ptr<Cmd> cmd_ptr,
       std::shared_ptr<PikaClientConn> conn_ptr,
-      std::shared_ptr<std::string> resp_ptr);
+      std::shared_ptr<std::string> resp_ptr, bool* saved);
   Status InternalAppendBinlog(const BinlogItem& item,
       std::shared_ptr<Cmd> cmd_ptr,
-      LogOffset* log_offset);
+      LogOffset* log_offset, bool* saved);
   void InternalApply(const MemLog::LogItem& log);
   void InternalApplyFollower(const MemLog::LogItem& log);
   bool InternalUpdateCommittedIndex(const LogOffset& slaves_committed_index,

--- a/include/pika_kv.h
+++ b/include/pika_kv.h
@@ -297,7 +297,8 @@ class SetnxCmd : public Cmd {
  private:
   std::string key_;
   std::string value_;
-  int32_t success_;
+  // slave write binlog first, then exec Do function. so this success_ should be true by default.
+  int32_t success_ = 1;
   virtual void DoInitial() override;
   virtual std::string ToBinlog(
       uint32_t exec_time,

--- a/src/pika_kv.cc
+++ b/src/pika_kv.cc
@@ -522,7 +522,7 @@ std::string SetnxCmd::ToBinlog(
     RedisAppendLen(content, 3, "*");
 
     // to set cmd
-    std::string set_cmd("set");
+    std::string set_cmd("setnx");
     RedisAppendLen(content, set_cmd.size(), "$");
     RedisAppendContent(content, set_cmd);
     // key


### PR DESCRIPTION
fixed: can't sync binlog when exec redis command  setnx  and the key was exist.