### PR TITLE
Typo in unknown command error message

### DIFF
--- a/src/pika_client_conn.cc
+++ b/src/pika_client_conn.cc
@@ -44,7 +44,7 @@ std::shared_ptr<Cmd> PikaClientConn::DoCmd(
   if (!c_ptr) {
     std::shared_ptr<Cmd> tmp_ptr = std::make_shared<DummyCmd>(DummyCmd());
     tmp_ptr->res().SetRes(CmdRes::kErrOther,
-        "unknown or unsupported command \'" + opt + "\"");
+        "unknown or unsupported command \"" + opt + "\"");
     return tmp_ptr;
   }
   c_ptr->SetConn(std::dynamic_pointer_cast<PikaClientConn>(shared_from_this()));


### PR DESCRIPTION
This came up while trying to debug using vertx, which implements RESP2 and RESP3 and tries to issue the `hello` command to figure out which protocol to speak. Pika doesn't implement the `hello` command but also has a non-standard error message, so vertx can't connect.

This PR doesn't fix the incompatibility with vertx, but fixes a typo regarding single and double quotes.