### PR TITLE
Use docker multi-stage build to reduce the docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
- FROM centos:7
+ FROM centos:7 as builder
 
 LABEL maintainer="SvenDowideit@home.org.au, zhangshaomin_1990@126.com"
 
@@ -34,7 +34,16 @@ RUN rpm -ivh https://mirrors.aliyun.com/epel/epel-release-latest-7.noarch.rpm &&
     yum -y remove git && \
     yum -y clean all 
 
+FROM centos:7
+ENV PIKA  /pika
+ENV PATH ${PIKA}:${PIKA}/bin:${PATH}
+
+RUN set -eux; yum install -y epel-release; \
+ yum install -y snappy protobuf gflags glog bzip2 zlib lz4 libzstd rsync; \
+ yum clean all;
+
 WORKDIR ${PIKA}
+COPY --from=builder $PIKA ./
 
 ENTRYPOINT ["/pika/entrypoint.sh"]
 CMD ["/pika/bin/pika", "-c", "/pika/conf/pika.conf"]


### PR DESCRIPTION
Since the official pika docker image size is quite large, around 2.15GB, we can use [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) to reduce the docker image size.

With multi-stage build, we reduce the pika docker image size to ~ 380MB:

<img width="733" alt="pika-docker-image-size@2x" src="https://user-images.githubusercontent.com/186645/119083341-5dd05e80-ba32-11eb-806c-1faa6855b95b.png">

Hope this PR can be accepted, thank you.
